### PR TITLE
Per-project configurations

### DIFF
--- a/text/0000-per-project-config.md
+++ b/text/0000-per-project-config.md
@@ -6,21 +6,21 @@
 # Summary
 [summary]: #summary
 
-Support Volta configuration of both hooks and platform information on a per-project basis using a `.voltarc.json` file in the project root.
+Support Volta configuration of hooks on a per-project basis using a `.volta/hooks.json` file in the project.
 
 # Motivation
 [motivation]: #motivation
 
 We currently only support Volta configuration on a per-user basis in the `hooks.toml` file. This file allows users to change the URLs that tools are downloaded from. However, since a user could be working on both an open-source project (that uses the public registry) and an internal project (that uses a private registry), we instead want to allow the users to specify these settings on a per-project basis.
 
-Additionally, we currently already support per-project settings for the platform (node, npm, and yarn versions), specified in the `toolchain` key inside of `package.json`. Multiple users have requested an alternate method in a separate file, for various reasons (see https://github.com/notion-cli/notion/issues/282 for some discussion of one use-case). As we are already looking at adding per-project hooks to a separate file, that file should also support specifying the platform information.
+To allow for the potential of additional per-project Volta configurations in the future, we want to store this file in a `.volta` directory at the project root.
 
 # Pedagogy
 [pedagogy]: #pedagogy
 
-We need to document the format of the `.voltarc.json` file, which will mostly match the features available in the existing `hooks.toml`, however it will also include the additional settings for `toolchain` similar to `package.json`. Additionally, we need to document and explain the precedence order for when multiple configs are specified (e.g. user-level _and_ project-level).
+We need to document the format of the `hooks.json` file, which will match the features available in the existing `hooks.toml`. We also need to document the existence of a `.volta` directory within a project for per-project configurations. Additionally, we need to document and explain the precedence order for when multiple configs are specified (e.g. user-level _and_ project-level).
 
-Additionally, for consistency of configuration, we should update the user-wide config stored in `~/.volta` from `hooks.toml` to also be named `.voltarc.json`, so that it's immediately obvious that it contains the same settings as the project-level configuration. This will be a breaking change that requires users to translate their settings from the old format to the new.
+Finally, for consistency of configuration, we should update the user-wide config stored in `~/.volta` from `hooks.toml` to also be named `hooks.json`, so that it's immediately obvious that it contains the same settings as the project-level configuration. This will not be a breaking change since the existing `hooks.toml` format wasn't documented and wasn't part of our public API.
 
 This feature will primarily be used for more advanced use-cases, as the default public repositories and `package.json` settings should cover the majority of open-source projects.
 
@@ -29,42 +29,27 @@ This feature will primarily be used for more advanced use-cases, as the default 
 
 ## User-level configuration file
 
-We will need to update the `HookConfig` to parse the user-level `.voltarc.json`, if it exists. We should also allow the user to specify the user platform (`node`, `npm`, and `yarn`) in that file. To that end, we can likely merge the existing `~/.volta/tools/user/platform.json` into `~/.volta/.voltarc.json` as our source of truth for the user-default selected versions. This may also allow us to simplify some of the logic around determining the currently active platform, as we can merge all of the available configs into a single result once, and then use that to execute a tool.
+We will need to update the `HookConfig` to parse the user-level `hooks.json`, if it exists, instead of the `hooks.toml` file.
 
 ## Configuration Precedence
 
-When configurations are specified in multiple places, we need to deep merge them in a specified order so that we get a single configuration to work from. The order will be defined generally as more specific configurations having precedence over more general configurations. This means:
-
-- Per-project configuration beats per-user configuration
-- `.voltarc.json` platform spec must match `package.json` platform spec if both are specified
+When configurations are specified in multiple places, we need to deep merge them in a specified order so that we get a single configuration to work from. The order will be defined generally as more specific configurations having precedence over more general configurations. This means that per-project settings will beat per-user settings.
 
 ## Merging Configurations
 
 When multiple configurations are specified, we should merge them deeply using the above precedence such that the final configuration includes all hooks defined by any of the configurations. For example, if:
 
-- User-level `.voltarc.json` includes the `[node.index]` and `[node.distro]` hooks
-- Project-level `.voltarc.json` includes the `[node.distro]` hook
+- User-level `hooks.json` includes the `[node.index]` and `[node.distro]` hooks
+- Project-level `.volta/hooks.json` includes the `[node.distro]` hook
 
 The final configuration that Volta uses will have:
 
-- `[node.index]` hook from user-level `.voltarc.json`
-- `[node.distro]` hook from project-level `.voltarc.json`
-
-This will likely require that the `Project` and `Hooks` objects in `volta-core` are merged in some way into a single configuration object that pulls from all possible sources.
-
-Additionally, if the platform spec is provided in both `.voltarc.json` _and_ in `package.json`, they must be the same or we will throw an error. This will prevent confusion around which file "wins" and what the source of truth is for the project. The documentation should strongly recommend that one or the other is specified, not both.
+- `[node.index]` hook from user-level `hooks.json`
+- `[node.distro]` hook from project-level `hooks.json`
 
 ## `volta config` Reference
 
 To help users understand which configurations are active and where they are coming from, we should implement a `volta config list` command that works similarly to `npm config list`. This will allow users to immediately see what Volta understands about the state of the world from a given place in the filesystem, while also providing us with a useful tool for debugging the implementation. This also opens the option going forward of providing CLI commands for editing the configuration (e.g. `volta config set`).
-
-## Multi-stage Implementation
-
-To facilitate the work and allow users to work with parts of these changes before we make an entire overhaul to the system, we can implement this RFC in multiple stages:
-
-1. Add support for parsing a project-local `volta-hooks.toml` file, if it exists, as well as the `~/.volta/hooks.toml` that we currently check for.
-2. Rename `hooks.toml` into `.voltarc.json`, changing the file format but supporting the same set of configurations (i.e. Only hooks, no platform specifications at this point).
-3. Fully merge the hooks config with the platform config internally and add support for `toolchain` within `.voltarc.json`
 
 # Critique
 [critique]: #critique
@@ -73,15 +58,11 @@ To facilitate the work and allow users to work with parts of these changes befor
 
 One possible update is that a different precedence order could be used for the configurations. However, it is a common pattern in computing that more specific settings beat less specific settings, so we should still adhere to that. Additionally, the specific-to-general precedence order matches the order used by `npm` for `npmrc` files.
 
-As discussed above, the project-level `.voltarc.json` setting is considered to be a more "advanced" way of specifying per-project settings, so it should have precedence over `package.json`.
-
 ## Merging Configurations
 
-Another approach to determining the final configuration from the available files would be to use _only_ the highest-precedence `.voltarc.json` if it is present and fall back to the existing `package.json` if there isn't a `.voltarc.json` present. This would mean that if any `.voltarc.json` is present, it represents the single source of truth for all of the Volta settings. However, it would remove the ability to have settings cascade down from the user-level settings to the project-level settings when a project doesn't have any custom configuration beyond what the user has specified.
+Another approach to determining the final configuration from the available files would be to use _only_ the highest-precedence `hooks.json` if it is present, This would mean that if any `hooks.json` is present, it represents the single source of truth for all of the Volta hooks. However, it would remove the ability to have settings cascade down from the user-level settings to the project-level settings when a project doesn't have any custom configuration beyond what the user has specified.
 
 The merge approach suggested in the RFC matches how `npm` resolves configuration from multiple sources, pulling each value in precedence order, but allowing different files to specify different settings.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
-
-- What additional settings, if any, should we include in `.voltarc.json`?

--- a/text/0000-per-project-config.md
+++ b/text/0000-per-project-config.md
@@ -64,6 +64,10 @@ Another approach to determining the final configuration from the available files
 
 The merge approach suggested in the RFC matches how `npm` resolves configuration from multiple sources, pulling each value in precedence order, but allowing different files to specify different settings.
 
+## File Layout
+
+An alternative to using a `.volta` directory with independent files would be to have a single `.voltarc` or `.voltarc.json` file in the root of the project. The trouble with this approach is that it would require any future project-level configuration we decide to add to also be in the same file. In a corporate setting, it's reasonable to expect that different groups will be responsible for managing different configurations (i.e. one group is in charge of changes to the hooks while another group manages the `node` platform settings). In this case, it would be preferable to have the files be separate, so to future-proof the design, we decided on having a configuration directory that can hold any number of independent files.
+
 ## File Format
 
 Instead of using `.json`, we could use a format that supports comments for our configuration files, such as `.toml`. This would have the advantage of allowing the configuration to be more expressive, but would require a learning curve for a majority of our users, who don't necessarily have experience with `.toml`. By using `.json`, we're using a format that is a standard in the JS ecosystem, so the learning curve will be lowered. Additionally, there are proposals for extensions of JSON that support comments, so in the future we could adopt those in a backwards-compatible way, which would allow us to support comments without breaking existing users.

--- a/text/0000-per-project-config.md
+++ b/text/0000-per-project-config.md
@@ -1,26 +1,26 @@
 - Feature Name: per-project-config
 - Start Date: 2019-05-01
 - RFC PR: (leave this empty)
-- Notion Issue: (leave this empty)
+- Volta Issue: (leave this empty)
 
 # Summary
 [summary]: #summary
 
-Support Notion configuration of both hooks and platform information on a per-project basis using a `.notionrc.json` file in the project root.
+Support Volta configuration of both hooks and platform information on a per-project basis using a `.voltarc.json` file in the project root.
 
 # Motivation
 [motivation]: #motivation
 
-We currently only support Notion configuration on a per-user basis in the `hooks.toml` file. This file allows users to change the URLs that tools are downloaded from. However, since a user could be working on both an open-source project (that uses the public registry) and an internal project (that uses a private registry), we instead want to allow the users to specify these settings on a per-project basis.
+We currently only support Volta configuration on a per-user basis in the `hooks.toml` file. This file allows users to change the URLs that tools are downloaded from. However, since a user could be working on both an open-source project (that uses the public registry) and an internal project (that uses a private registry), we instead want to allow the users to specify these settings on a per-project basis.
 
 Additionally, we currently already support per-project settings for the platform (node, npm, and yarn versions), specified in the `toolchain` key inside of `package.json`. Multiple users have requested an alternate method in a separate file, for various reasons (see https://github.com/notion-cli/notion/issues/282 for some discussion of one use-case). As we are already looking at adding per-project hooks to a separate file, that file should also support specifying the platform information.
 
 # Pedagogy
 [pedagogy]: #pedagogy
 
-We need to document the format of the `.notionrc.json` file, which will mostly match the features available in the existing `hooks.toml`, however it will also include the additional settings for `toolchain` similar to . Additionally, we need to document and explain the precedence order for when multiple configs are specified (e.g. user-level _and_ project-level).
+We need to document the format of the `.voltarc.json` file, which will mostly match the features available in the existing `hooks.toml`, however it will also include the additional settings for `toolchain` similar to . Additionally, we need to document and explain the precedence order for when multiple configs are specified (e.g. user-level _and_ project-level).
 
-Additionally, for consistency of configuration, we should update the user-wide config stored in `~/.notion` from `hooks.toml` to also be named `.notionrc.json`, so that it's immediately obvious that it contains the same settings as the project-level configuration. This will be a breaking change that requires users to translate their settings from the old format to the new.
+Additionally, for consistency of configuration, we should update the user-wide config stored in `~/.volta` from `hooks.toml` to also be named `.voltarc.json`, so that it's immediately obvious that it contains the same settings as the project-level configuration. This will be a breaking change that requires users to translate their settings from the old format to the new.
 
 This feature will primarily be used for more advanced use-cases, as the default public repositories and `package.json` settings should cover the majority of open-source projects.
 
@@ -29,42 +29,42 @@ This feature will primarily be used for more advanced use-cases, as the default 
 
 ## User-level configuration file
 
-We will need to update the `HookConfig` to parse the user-level `.notionrc.json`, if it exists. We should also allow the user to specify the user platform (`node`, `npm`, and `yarn`) in that file. To that end, we can likely merge the existing `~/.notion/tools/user/platform.json` into `~/.notion/.notionrc.json` as our source of truth for the user-default selected versions. This may also allow us to simplify some of the logic around determining the currently active platform, as we can merge all of the available configs into a single result once, and then use that to execute a tool.
+We will need to update the `HookConfig` to parse the user-level `.voltarc.json`, if it exists. We should also allow the user to specify the user platform (`node`, `npm`, and `yarn`) in that file. To that end, we can likely merge the existing `~/.volta/tools/user/platform.json` into `~/.volta/.voltarc.json` as our source of truth for the user-default selected versions. This may also allow us to simplify some of the logic around determining the currently active platform, as we can merge all of the available configs into a single result once, and then use that to execute a tool.
 
 ## Configuration Precedence
 
 When configurations are specified in multiple places, we need to deep merge them in a specified order so that we get a single configuration to work from. The order will be defined generally as more specific configurations having precedence over more general configurations. This means:
 
 - Per-project configuration beats per-user configuration
-- `.notionrc.json` platform spec beats `package.json` platform spec
+- `.voltarc.json` platform spec must match `package.json` platform spec if both are specified
 
 ## Merging Configurations
 
 When multiple configurations are specified, we should merge them deeply using the above precedence such that the final configuration includes all hooks defined by any of the configurations. For example, if:
 
-- User-level `.notionrc.json` includes the `[node.index]` and `[node.distro]` hooks
-- Project-level `.notionrc.json` includes the `[node.distro]` hook and the `node` version setting for the platform
-- `package.json` includes both `node` and `yarn` for the platform
+- User-level `.voltarc.json` includes the `[node.index]` and `[node.distro]` hooks
+- Project-level `.voltarc.json` includes the `[node.distro]` hook
 
-The final configuration that Notion uses will have:
+The final configuration that Volta uses will have:
 
-- `[node.index]` hook from user-level `.notionrc.json`
-- `yarn` version from `package.json`
-- `[node.distro]` hook and `node` version from project-level `.notionrc.json`
+- `[node.index]` hook from user-level `.voltarc.json`
+- `[node.distro]` hook from project-level `.voltarc.json`
 
-This will likely require that the `Project` and `Hooks` objects in `notion-core` are merged in some way into a single configuration object that pulls from all possible sources.
+This will likely require that the `Project` and `Hooks` objects in `volta-core` are merged in some way into a single configuration object that pulls from all possible sources.
 
-## `notion config` Reference
+Additionally, if the platform spec is provided in both `.voltarc.json` _and_ in `package.json`, they must be the same or we will throw an error. This will prevent confusion around which file "wins" and what the source of truth is for the project. The documentation should strongly recommend that one or the other is specified, not both.
 
-To help users understand which configurations are active and where they are coming from, we should implement a `notion config list` command that works similarly to `npm config list`. This will allow users to immediately see what Notion understands about the state of the world from a given place in the filesystem, while also providing us with a useful tool for debugging the implementation. This also opens the option going forward of providing CLI commands for editing the configuration (e.g. `notion config set`).
+## `volta config` Reference
+
+To help users understand which configurations are active and where they are coming from, we should implement a `volta config list` command that works similarly to `npm config list`. This will allow users to immediately see what Volta understands about the state of the world from a given place in the filesystem, while also providing us with a useful tool for debugging the implementation. This also opens the option going forward of providing CLI commands for editing the configuration (e.g. `volta config set`).
 
 ## Multi-stage Implementation
 
 To facilitate the work and allow users to work with parts of these changes before we make an entire overhaul to the system, we can implement this RFC in multiple stages:
 
-1. Add support for parsing a project-local `notion-hooks.toml` file, if it exists, as well as the `~/.notion/hooks.toml` that we currently check for.
-2. Rename `hooks.toml` into `.notionrc.json`, changing the file format but supporting the same set of configurations (i.e. Only hooks, no platform specifications at this point).
-3. Fully merge the hooks config with the platform config internally and add support for `toolchain` within `.notionrc.json`
+1. Add support for parsing a project-local `volta-hooks.toml` file, if it exists, as well as the `~/.volta/hooks.toml` that we currently check for.
+2. Rename `hooks.toml` into `.voltarc.json`, changing the file format but supporting the same set of configurations (i.e. Only hooks, no platform specifications at this point).
+3. Fully merge the hooks config with the platform config internally and add support for `toolchain` within `.voltarc.json`
 
 # Critique
 [critique]: #critique
@@ -73,15 +73,15 @@ To facilitate the work and allow users to work with parts of these changes befor
 
 One possible update is that a different precedence order could be used for the configurations. However, it is a common pattern in computing that more specific settings beat less specific settings, so we should still adhere to that. Additionally, the specific-to-general precedence order matches the order used by `npm` for `npmrc` files.
 
-As discussed above, the project-level `.notionrc.json` setting is considered to be a more "advanced" way of specifying per-project settings, so it should have precedence over `package.json`.
+As discussed above, the project-level `.voltarc.json` setting is considered to be a more "advanced" way of specifying per-project settings, so it should have precedence over `package.json`.
 
 ## Merging Configurations
 
-Another approach to determining the final configuration from the available files would be to use _only_ the highest-precedence `.notionrc.json` if it is present and fall back to the existing `package.json` if there isn't a `.notionrc.json` present. This would mean that if any `.notionrc.json` is present, it represents the single source of truth for all of the Notion settings. However, it would remove the ability to have settings cascade down from the user-level settings to the project-level settings when a project doesn't have any custom configuration beyond what the user has specified.
+Another approach to determining the final configuration from the available files would be to use _only_ the highest-precedence `.voltarc.json` if it is present and fall back to the existing `package.json` if there isn't a `.voltarc.json` present. This would mean that if any `.voltarc.json` is present, it represents the single source of truth for all of the Volta settings. However, it would remove the ability to have settings cascade down from the user-level settings to the project-level settings when a project doesn't have any custom configuration beyond what the user has specified.
 
 The merge approach suggested in the RFC matches how `npm` resolves configuration from multiple sources, pulling each value in precedence order, but allowing different files to specify different settings.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-- What additional settings, if any, should we include in `.notionrc.json`?
+- What additional settings, if any, should we include in `.voltarc.json`?

--- a/text/0000-per-project-config.md
+++ b/text/0000-per-project-config.md
@@ -33,14 +33,14 @@ We will need to update the `HookConfig` to parse the user-level `.notionrc.json`
 
 ## Configuration Precedence
 
-When configurations are specified in multiple places, we need to merge them in a specified order so that we get a single configuration to work from. The order will be defined generally as more specific configurations having precedence over more general configurations. This means:
+When configurations are specified in multiple places, we need to deep merge them in a specified order so that we get a single configuration to work from. The order will be defined generally as more specific configurations having precedence over more general configurations. This means:
 
 - Per-project configuration beats per-user configuration
 - `.notionrc.json` platform spec beats `package.json` platform spec
 
 ## Merging Configurations
 
-When multiple configurations are specified, we should merge them using the above precedence such that the final configuration includes all hooks defined by any of the configurations. For example, if:
+When multiple configurations are specified, we should merge them deeply using the above precedence such that the final configuration includes all hooks defined by any of the configurations. For example, if:
 
 - User-level `.notionrc.json` includes the `[node.index]` and `[node.distro]` hooks
 - Project-level `.notionrc.json` includes the `[node.distro]` hook and the `node` version setting for the platform

--- a/text/0000-per-project-config.md
+++ b/text/0000-per-project-config.md
@@ -56,7 +56,15 @@ This will likely require that the `Project` and `Hooks` objects in `notion-core`
 
 ## `notion config` Reference
 
-To help users understand which configurations are active and where they are coming from, we should implement a `notion config` command that works similarly to `npm config`. This will likely require a separate RFC to work out the specific details of how we show configurations and sources. We'll also need to figure out if the user can set configurations from the command-line, and if so, how we propagate those settings back into the various config files.
+To help users understand which configurations are active and where they are coming from, we should implement a `notion config list` command that works similarly to `npm config list`. This will allow users to immediately see what Notion understands about the state of the world from a given place in the filesystem, while also providing us with a useful tool for debugging the implementation. This also opens the option going forward of providing CLI commands for editing the configuration (e.g. `notion config set`).
+
+## Multi-stage Implementation
+
+To facilitate the work and allow users to work with parts of these changes before we make an entire overhaul to the system, we can implement this RFC in multiple stages:
+
+1. Add support for parsing a project-local `notion-hooks.toml` file, if it exists, as well as the `~/.notion/hooks.toml` that we currently check for.
+2. Rename `hooks.toml` into `.notionrc.json`, changing the file format but supporting the same set of configurations (i.e. Only hooks, no platform specifications at this point).
+3. Fully merge the hooks config with the platform config internally and add support for `toolchain` within `.notionrc.json`
 
 # Critique
 [critique]: #critique

--- a/text/0000-per-project-config.md
+++ b/text/0000-per-project-config.md
@@ -6,62 +6,74 @@
 # Summary
 [summary]: #summary
 
-Support Notion configuration of both hooks and platform information on a per-project basis using a `.notionrc` file in the project root.
+Support Notion configuration of both hooks and platform information on a per-project basis using a `.notionrc.json` file in the project root.
 
 # Motivation
 [motivation]: #motivation
 
 We currently only support Notion configuration on a per-user basis in the `hooks.toml` file. This file allows users to change the URLs that tools are downloaded from. However, since a user could be working on both an open-source project (that uses the public registry) and an internal project (that uses a private registry), we instead want to allow the users to specify these settings on a per-project basis.
 
-Additionally, we currently already support per-project settings for the platform (node and yarn versions), specified in the `toolchain` key inside of `package.json`. Multiple users have requested an alternate method in a separate file, for various reasons (see https://github.com/notion-cli/notion/issues/282 for some discussion of one use-case). As we are already looking at adding per-project hooks to a separate file, that file should also support specifying the platform information.
+Additionally, we currently already support per-project settings for the platform (node, npm, and yarn versions), specified in the `toolchain` key inside of `package.json`. Multiple users have requested an alternate method in a separate file, for various reasons (see https://github.com/notion-cli/notion/issues/282 for some discussion of one use-case). As we are already looking at adding per-project hooks to a separate file, that file should also support specifying the platform information.
 
 # Pedagogy
 [pedagogy]: #pedagogy
 
-We need to document the format of the `.notionrc` file, which will mostly match the format of `hooks.toml`, however it will also include the additional settings for `node` and `yarn` versions. Additionally, we need to document and explain the precedence order for when multiple configs are specified (e.g. user-level `hooks.toml` _and_ project-level `.notionrc`).
+We need to document the format of the `.notionrc.json` file, which will mostly match the features available in the existing `hooks.toml`, however it will also include the additional settings for `toolchain` similar to . Additionally, we need to document and explain the precedence order for when multiple configs are specified (e.g. user-level _and_ project-level).
+
+Additionally, for consistency of configuration, we should update the user-wide config stored in `~/.notion` from `hooks.toml` to also be named `.notionrc.json`, so that it's immediately obvious that it contains the same settings as the project-level configuration. This will be a breaking change that requires users to translate their settings from the old format to the new.
 
 This feature will primarily be used for more advanced use-cases, as the default public repositories and `package.json` settings should cover the majority of open-source projects.
 
 # Details
 [details]: #details
 
+## User-level configuration file
+
+We will need to update the `HookConfig` to parse the user-level `.notionrc.json`, if it exists. We should also allow the user to specify the user platform (`node`, `npm`, and `yarn`) in that file. To that end, we can likely merge the existing `~/.notion/tools/user/platform.json` into `~/.notion/.notionrc.json` as our source of truth for the user-default selected versions. This may also allow us to simplify some of the logic around determining the currently active platform, as we can merge all of the available configs into a single result once, and then use that to execute a tool.
+
 ## Configuration Precedence
 
 When configurations are specified in multiple places, we need to merge them in a specified order so that we get a single configuration to work from. The order will be defined generally as more specific configurations having precedence over more general configurations. This means:
 
 - Per-project configuration beats per-user configuration
-- `.notionrc` platform spec beats `package.json` platform spec
+- `.notionrc.json` platform spec beats `package.json` platform spec
 
 ## Merging Configurations
 
 When multiple configurations are specified, we should merge them using the above precedence such that the final configuration includes all hooks defined by any of the configurations. For example, if:
 
-- `hooks.toml` includes the `[node.index]` and `[node.distro]` hooks
-- `.notionrc` includes the `[node.distro]` hook and the `node` version setting for the platform
+- User-level `.notionrc.json` includes the `[node.index]` and `[node.distro]` hooks
+- Project-level `.notionrc.json` includes the `[node.distro]` hook and the `node` version setting for the platform
 - `package.json` includes both `node` and `yarn` for the platform
 
 The final configuration that Notion uses will have:
 
-- `[node.index]` hook from `hooks.toml`
+- `[node.index]` hook from user-level `.notionrc.json`
 - `yarn` version from `package.json`
-- `[node.distro]` hook and `node` version from `.notionrc`
+- `[node.distro]` hook and `node` version from project-level `.notionrc.json`
 
 This will likely require that the `Project` and `Hooks` objects in `notion-core` are merged in some way into a single configuration object that pulls from all possible sources.
+
+## `notion config` Reference
+
+To help users understand which configurations are active and where they are coming from, we should implement a `notion config` command that works similarly to `npm config`. This will likely require a separate RFC to work out the specific details of how we show configurations and sources. We'll also need to figure out if the user can set configurations from the command-line, and if so, how we propagate those settings back into the various config files.
 
 # Critique
 [critique]: #critique
 
 ## Configuration Precedence
 
-One possible update is that a different precedence order could be used for the configurations. However, it is a common pattern in computing that more specific settings beat less specific settings, so we should still adhere to that. As discussed above, the `.notionrc` setting is considered to be a more "advanced" way of specifying per-project settings, so it should have precedence over `package.json`.
+One possible update is that a different precedence order could be used for the configurations. However, it is a common pattern in computing that more specific settings beat less specific settings, so we should still adhere to that. Additionally, the specific-to-general precedence order matches the order used by `npm` for `npmrc` files.
+
+As discussed above, the project-level `.notionrc.json` setting is considered to be a more "advanced" way of specifying per-project settings, so it should have precedence over `package.json`.
 
 ## Merging Configurations
 
-Another approach to determining the final configuration from the available files would be to use _only_ `.notionrc` if it is present and fall back to the existing combination of `package.json` and `hooks.toml` if there isn't a `.notionrc` present. This would mean that if `.notionrc` is present, it represents the single source of truth for all of the Notion settings. However, it would remove the ability to have settings cascade down from the user-level settings to the project-level settings when a project doesn't have any custom configuration beyond what the user has specified.
+Another approach to determining the final configuration from the available files would be to use _only_ the highest-precedence `.notionrc.json` if it is present and fall back to the existing `package.json` if there isn't a `.notionrc.json` present. This would mean that if any `.notionrc.json` is present, it represents the single source of truth for all of the Notion settings. However, it would remove the ability to have settings cascade down from the user-level settings to the project-level settings when a project doesn't have any custom configuration beyond what the user has specified.
+
+The merge approach suggested in the RFC matches how `npm` resolves configuration from multiple sources, pulling each value in precedence order, but allowing different files to specify different settings.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-- Should we also include additional settings in `.notionrc`?
-- Is there a better file name to use, other than `.notionrc`? `notion.toml` Perhaps?
-- Is TOML the best format, or should we use something else for this per-project configuration?
+- What additional settings, if any, should we include in `.notionrc.json`?

--- a/text/0000-per-project-config.md
+++ b/text/0000-per-project-config.md
@@ -64,5 +64,11 @@ Another approach to determining the final configuration from the available files
 
 The merge approach suggested in the RFC matches how `npm` resolves configuration from multiple sources, pulling each value in precedence order, but allowing different files to specify different settings.
 
+## File Format
+
+Instead of using `.json`, we could use a format that supports comments for our configuration files, such as `.toml`. This would have the advantage of allowing the configuration to be more expressive, but would require a learning curve for a majority of our users, who don't necessarily have experience with `.toml`. By using `.json`, we're using a format that is a standard in the JS ecosystem, so the learning curve will be lowered. Additionally, there are proposals for extensions of JSON that support comments, so in the future we could adopt those in a backwards-compatible way, which would allow us to support comments without breaking existing users.
+
 # Unresolved questions
 [unresolved]: #unresolved-questions
+
+- Should we allow users to specify platform information (`node`, `npm`, and `yarn` versions) in the `.volta` directory? If so, what format should it take?

--- a/text/0000-per-project-config.md
+++ b/text/0000-per-project-config.md
@@ -1,0 +1,67 @@
+- Feature Name: per-project-config
+- Start Date: 2019-05-01
+- RFC PR: (leave this empty)
+- Notion Issue: (leave this empty)
+
+# Summary
+[summary]: #summary
+
+Support Notion configuration of both hooks and platform information on a per-project basis using a `.notionrc` file in the project root.
+
+# Motivation
+[motivation]: #motivation
+
+We currently only support Notion configuration on a per-user basis in the `hooks.toml` file. This file allows users to change the URLs that tools are downloaded from. However, since a user could be working on both an open-source project (that uses the public registry) and an internal project (that uses a private registry), we instead want to allow the users to specify these settings on a per-project basis.
+
+Additionally, we currently already support per-project settings for the platform (node and yarn versions), specified in the `toolchain` key inside of `package.json`. Multiple users have requested an alternate method in a separate file, for various reasons (see https://github.com/notion-cli/notion/issues/282 for some discussion of one use-case). As we are already looking at adding per-project hooks to a separate file, that file should also support specifying the platform information.
+
+# Pedagogy
+[pedagogy]: #pedagogy
+
+We need to document the format of the `.notionrc` file, which will mostly match the format of `hooks.toml`, however it will also include the additional settings for `node` and `yarn` versions. Additionally, we need to document and explain the precedence order for when multiple configs are specified (e.g. user-level `hooks.toml` _and_ project-level `.notionrc`).
+
+This feature will primarily be used for more advanced use-cases, as the default public repositories and `package.json` settings should cover the majority of open-source projects.
+
+# Details
+[details]: #details
+
+## Configuration Precedence
+
+When configurations are specified in multiple places, we need to merge them in a specified order so that we get a single configuration to work from. The order will be defined generally as more specific configurations having precedence over more general configurations. This means:
+
+- Per-project configuration beats per-user configuration
+- `.notionrc` platform spec beats `package.json` platform spec
+
+## Merging Configurations
+
+When multiple configurations are specified, we should merge them using the above precedence such that the final configuration includes all hooks defined by any of the configurations. For example, if:
+
+- `hooks.toml` includes the `[node.index]` and `[node.distro]` hooks
+- `.notionrc` includes the `[node.distro]` hook and the `node` version setting for the platform
+- `package.json` includes both `node` and `yarn` for the platform
+
+The final configuration that Notion uses will have:
+
+- `[node.index]` hook from `hooks.toml`
+- `yarn` version from `package.json`
+- `[node.distro]` hook and `node` version from `.notionrc`
+
+This will likely require that the `Project` and `Hooks` objects in `notion-core` are merged in some way into a single configuration object that pulls from all possible sources.
+
+# Critique
+[critique]: #critique
+
+## Configuration Precedence
+
+One possible update is that a different precedence order could be used for the configurations. However, it is a common pattern in computing that more specific settings beat less specific settings, so we should still adhere to that. As discussed above, the `.notionrc` setting is considered to be a more "advanced" way of specifying per-project settings, so it should have precedence over `package.json`.
+
+## Merging Configurations
+
+Another approach to determining the final configuration from the available files would be to use _only_ `.notionrc` if it is present and fall back to the existing combination of `package.json` and `hooks.toml` if there isn't a `.notionrc` present. This would mean that if `.notionrc` is present, it represents the single source of truth for all of the Notion settings. However, it would remove the ability to have settings cascade down from the user-level settings to the project-level settings when a project doesn't have any custom configuration beyond what the user has specified.
+
+# Unresolved questions
+[unresolved]: #unresolved-questions
+
+- Should we also include additional settings in `.notionrc`?
+- Is there a better file name to use, other than `.notionrc`? `notion.toml` Perhaps?
+- Is TOML the best format, or should we use something else for this per-project configuration?

--- a/text/0025-config-hooks.md
+++ b/text/0025-config-hooks.md
@@ -1,7 +1,7 @@
 - Feature Name: config_hooks
 - Start Date: 10/31/2018
-- RFC PR: (leave this empty)
-- Notion Issue: (leave this empty)
+- RFC PR: https://github.com/notion-cli/rfcs/pull/25
+- Notion Issue: https://github.com/notion-cli/notion/pull/241
 
 # Summary
 [summary]: #summary


### PR DESCRIPTION
> Support Volta configuration of hooks on a per-project basis using a `.volta/hooks.json` file in the project.

[Rendered](https://github.com/charlespierce/rfcs/blob/per_project_config/text/0000-per-project-config.md)