### PR TITLE
RFC: introduce `volta list` and deprecate `volta current`

### DIFF
--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -511,9 +511,12 @@ This section discusses the tradeoffs considered in this proposal. This must incl
 [unresolved]: #unresolved-questions
 
 - Should the bare `list` command include:
+
     - all available package binaries?
     - a subset of package binaries once the number crosses a threshold, with instructions about how to see all?
     - no package binaries?
+
+    And how should that be presented in `plain` vs. `human` mode?
 
 <!-- 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -758,7 +758,7 @@ We could leave the current state of affairs as it is. However, users then have n
 # Unresolved questions
 [unresolved]: #unresolved-questions
 
-- Should the bare `list` command include:
+- Should the bare command include:
 
     - all available package binaries?
     - a subset of package binaries once the number crosses a threshold, with instructions about how to see all?
@@ -768,11 +768,7 @@ We could leave the current state of affairs as it is. However, users then have n
 
 - How should the current version be identified? It is currently marked with `(current @ <path>)`. Should this be `(from <path>)` or some other design?
 
-- Should the `list` command accept flags to narrow the search instead of subcommands, e.g. `volta list --node`, `volta list --yarn`, `volta list --package=typescript`, etc.?
-
-    - Is there value in supporting both the `tool` and `package` invocations, or should we collapse them and avoid the additional complexity of distinguishing between tools/binaries and their supplying packages?
-
-    - Should we simply parse a positional argument after `volta list` as `<node|npm|yarn|<package name>>`?
+- Should the command accept flags to narrow the search instead of a positional argument, e.g. `volta list --node`, `volta list --yarn`, `volta list --package=typescript`, etc.?
 
 - How should the built-in version of `npm` be displayed to the user? Options include:
     - associated with the runtime it ships with, e.g. `v12.2.0 (with npm v6.4.1)`

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -719,6 +719,10 @@ This section discusses the tradeoffs considered in this proposal. This must incl
 
 - Should the `list` command accept flags to narrow the search instead of subcommands, e.g. `volta list --node`, `volta list --yarn`, `volta list --package=typescript`, etc.?
 
+- How should the built-in version of `npm` be displayed to the user? Options include:
+    - associated with the runtime it ships with, e.g. `v12.2.0 (with npm v6.4.1)`
+    - as a packager, but indicating its source as a built-in, e.g. `npm v6.4.1 (built-in from node@v12.2.0`
+
 <!-- 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?
 - What parts of the design do you expect to resolve through the implementation of this feature before stabilization?

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -42,7 +42,7 @@ Throughout, we will assume the user has the following configuration for illustra
 
 They also have two projects with the following pins:
 
-- `~/pinned/node-only/package.json`:
+- `~/node-only/package.json`:
 
     ```json
     {
@@ -52,7 +52,7 @@ They also have two projects with the following pins:
     }
     ```
 
-- `~/pinned/node-and-yarn/package.json`:
+- `~/node-and-yarn/package.json`:
 
     ```json
     {
@@ -75,8 +75,8 @@ The format is:
 $ volta list
 ⚡️ Currently active toolchain:
 
-    Node: version [(default|project)]
-    <packager>: <built-in|version> [(default|project)]]
+    Node: version [(default|<project path>)]
+    <packager>: <built-in|version> [(default|<project path>)]]
     Tool binaries available:
         <comma separated list|NONE>
 
@@ -107,7 +107,7 @@ See options for more detailed reports by running `volta list --help`.
 $ volta list
 ⚡️ Currently active toolchain:
 
-    Node: v8.16.0 (from `~/pinned/node-only/package.json`)
+    Node: v8.16.0 (from `~/node-only/package.json`)
     Yarn: v1.12.3 (default)
     Tool binaries available:
         create-react-app, ember, tsc, tsserver, yarn-deduplicate
@@ -123,8 +123,8 @@ See options for more detailed reports by running `volta list --help`.
 $ volta list
 ⚡️ Currently active toolchain:
 
-    Node: v12.2.0 (from `~/pinned/node-and-yarn/package.json`)
-    Yarn: v1.16.0 (from `~/pinned/node-and-yarn/package.json`)
+    Node: v12.2.0 (from `~/node-and-yarn/package.json`)
+    Yarn: v1.16.0 (from `~/node-and-yarn/package.json`)
     Tool binaries available:
         create-react-app, ember, tsc, tsserver, yarn-deduplicate
 
@@ -142,15 +142,15 @@ The basic format is:
 ```sh
 $ volta list --all
 Node runtimes:
-    <version> [(default|project)]
+    <version> [(default|<project path>)]
 
 Packagers:
     (Yarn|npm):
-        <version> [(default|project)]
+        <version> [(default|<project path>)]
 
 Tools:
     <tool name>
-        <version> [(default|project)]
+        <version> [(default|<project path>)]
             binaries: [<binary name>]...
             platform:
                 runtime: node@<version>
@@ -270,7 +270,7 @@ Tools:
 ```sh
 $ volta list --all
 Node runtimes:
-    v12.2.0 (project)
+    v12.2.0 (`~/node-and-yarn/project.json`)
     v11.9.0
     v10.15.3 (default)
     v8.16.0
@@ -278,7 +278,7 @@ Node runtimes:
 Packagers:
     Yarn:
         v1.16.0 (default)
-        v1.12.3 (project)
+        v1.12.3 (`~/node-and-yarn/project.json`)
 
 Tools:
     create-react-app:

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -700,11 +700,48 @@ This section should return to the examples given in the previous section, and ex
 # Critique
 [critique]: #critique
 
-This section discusses the tradeoffs considered in this proposal. This must include an honest accounting of the drawbacks of the proposal, as well as list out all the alternatives that were considered and rationale for why this proposal was chosen over the alternatives. This section should address questions such as:
+## Use another command name
 
-- Why is this design the best in the space of possible designs?
-- What other designs have been considered and what is the rationale for not choosing them?
-- What is the impact of not doing this?
+As noted in [**Why `list`?**][why-list], options for this subcommand name include `list`, `ls`, `tools`, `toolchain`, `info`, and `current`. (For discussion of shorthands, see the next section.) Given the considerable [prior art][prior-art] using `list`, however, it seems the best option in terms of what users will expect.
+
+If another option is preferred, e.g. `toolchain`, `list` could be a (hidden) alias for the actual subcommand.
+
+## Use shorthands instead of `list`
+
+One alternative direction suggested by nodenv's approach is to supply shorthands:
+
+- `volta list package <package>` → `volta package <package>`
+- `volta list tool <tool>` → `volta tool <tool>`
+
+However, in nodenv's case, those subcommands are also used for installation, which we are *not* doing under the current design of `install`. Moreover, the distinction drawn above is *not* presented in our installation process. That is, we do not actually allow users to install *tools* by name today, only *packages*. (This may suggest a simplification is in order; see [Unresolved Questions][unresolved] below.)
+
+Additionally, we might consider here (and people have suggested in discussions in Discord) that we simply make the bare `volta` output the equivalent of `volta list`, with `volta --help` or `volta help` being required for the full help details. In this scenario, we would presumably also include a message to that effect for non-TTY, human-friendly contexts, so:
+
+```sh
+$ volta
+⚡️ Volta 0.5.2
+Currently active tools:
+
+    Node: v8.16.0 (default)
+    Yarn: v1.12.3 (from ~/node-and-yarn/package.json)
+    Tool binaries available:
+        create-react-app, ember, tsc, tsserver
+
+To install a tool in your toolchain, use `volta install`.
+To pin your project's runtime or package manager, use `volta pin`.
+
+See `volta help` for more options!
+```
+
+This would be a substantial change, and require considerably more work, but it might be a nice experience!
+
+## Keep `volta current` as an alias for `volta list`
+
+Rather than deprecating `volta current`, we could make it an alias for `volta list`. The primary downside to doing this is that we would want it to work for *only* the equivalent of *bare* `volta list`, and not support any subcommands. This might be mildly confusing to users, but that possibility of confusion should be balanced against the utility of meeting people's existing expectations.
+
+## Do not add `list`
+
+We could leave the current state of affairs as it is. However, users then have no insight into their toolchain: they must inspect the internals of `~/.volta`  to see what they actually have on their system, and in order to see what version of a tool is going to be used, they have must actually invoke it or run `volta which` and interpret the path.
 
 # Unresolved questions
 [unresolved]: #unresolved-questions
@@ -720,6 +757,10 @@ This section discusses the tradeoffs considered in this proposal. This must incl
 - How should the current version be identified? It is currently marked with `(current @ <path>)`. Should this be `(from <path>)` or some other design?
 
 - Should the `list` command accept flags to narrow the search instead of subcommands, e.g. `volta list --node`, `volta list --yarn`, `volta list --package=typescript`, etc.?
+
+    - Is there value in supporting both the `tool` and `package` invocations, or should we collapse them and avoid the additional complexity of distinguishing between tools/binaries and their supplying packages?
+
+    - Should we simply parse a positional argument after `volta list` as `<node|npm|yarn|<package name>>`?
 
 - How should the built-in version of `npm` be displayed to the user? Options include:
     - associated with the runtime it ships with, e.g. `v12.2.0 (with npm v6.4.1)`

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -93,7 +93,7 @@ The tool will support multiple modes (two initially), which include exactly the 
     - tools: 
 
         ```
-        tool <tool name>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|<project path>)]
+        tool <tool name>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
         ```
 
 This RFC does not propose, but allows for the possibility of, a JSON mode (`--print=json`) or similar at a later time if that proves desirable.
@@ -174,8 +174,8 @@ The format is:
 
 ```sh
 $ volta list
-runtime node@<version> (default|<project path>)
-packager <npm|yarn>@<version> (built-in|default|<project path>)
+runtime node@<version> (default|current@ <project path>)
+packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 ```
 
 <details><summary>Outside a project</summary>
@@ -229,7 +229,7 @@ $ volta list --all
     
     Tools:
         <tool name>
-            <version> [(default|<project path>)]
+            <version> [(default|current @ <project path>)]
                 binaries: [<binary name>]...
                 platform:
                     runtime: node@<version>

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -221,10 +221,13 @@ They also have two projects with the following pins:
     }
     ```
 
-- `~/node-and-yarn/package.json`:
+- `~/node-yarn-ember/package.json`:
 
     ```json
     {
+      "devDependencies": {
+        "ember-cli": "v3.8.2",
+      },
       "volta": {
         "node": "v12.2.0",
         "yarn": "v1.16.0"
@@ -245,7 +248,7 @@ Currently active tools:
     Node: <version> (default|current @ <project path>)
     <Yarn|npm>: v1.12.3 (default|current @ <project path>)
     Package binaries available: [NONE]
-        [<tool name>,...]
+        <tool name>[, <tool name>...] (default|current @ <project path>)
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -259,7 +262,7 @@ Currently active tools:
     Node: v8.16.0 (default)
     Yarn: v1.12.3 (default)
     Package binaries available:
-        create-react-app, ember, tsc, tsserver
+        create-react-app, ember, tsc, tsserver (default)
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -268,32 +271,31 @@ See options for more detailed reports by running `volta list --help`.
 
 <details><summary>In the `node-only` project</summary>
 
-<b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
-
 ```sh
 $ volta list --format=human
 Currently active tools:
 
-    Node: v8.16.0 (current @ ~/node-only/package.json)
+    Node: v8.16.0 (@ ~/node-only/package.json)
     Yarn: v1.12.3 (default)
     Package binaries available:
-        create-react-app, ember, tsc, tsserver
+        create-react-app, ember, tsc, tsserver (default)
 
 See options for more detailed reports by running `volta list --help`.
 ```
 
 </details>
 
-<details><summary>In the <code>node-and-yarn</code> project</summary>
+<details><summary>In the <code>node-yarn-ember</code> project</summary>
 
 ```sh
 $ volta list --format=human
 Currently active tools:
 
-    Node runtime: v12.2.0 (current @ ~/node-and-yarn/package.json)
-    Package manager: Yarn: v1.16.0 (current @ ~/node-and-yarn/package.json)
+    Node runtime: v12.2.0 (@ ~/node-yarn-ember/package.json)
+    Package manager: Yarn: v1.16.0 (@ ~/node-yarn-ember/package.json)
     Package binaries available:
-        create-react-app, ember, tsc, tsserver
+        create-react-app, tsc, tsserver (default)
+        ember (current @ ~/node-yarn-ember/package.json) 
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -332,12 +334,12 @@ package-manager yarn@v1.12.3 (default)
 
 </details>
 
-<details><summary>In the <code>node-and-yarn</code> project</summary>
+<details><summary>In the <code>node-yarn-ember</code> project</summary>
 
 ```sh
 $ volta list --format=plain
-runtime node@v12.2.0 (~/node-and-yarn/package.json)
-package-manager yarn@v1.16.0 (~/node-and-yarn/package.json)
+runtime node@v12.2.0 (~/node-yarn-ember/package.json)
+package-manager yarn@v1.16.0 (~/node-yarn-ember/package.json)
 ```
 
 </details>
@@ -353,29 +355,20 @@ $ volta list all --format=human
 User toolchain:
 
     Node runtimes:
-        [default: <version>]
-        [current: <version> (@ <project path>)]
-        [fetched: <version>[, <version>...]]
+        <version> (default|current @ <project path>|fetched)
 
     Package managers:
         (Yarn|npm):
-            [default: <version>]
-            [current: <version> (@ <project path>)]
-            [fetched: <version>[, <version>...]]
+        <version> (default|current @ <project path>|fetched)
 
     Packages:
         <package name>
-            [current: <version> @ <project path>
+            [<version> (default | current @ <project path>)
                 binaries: [<binary name>]...
                 platform:
                     runtime: node@<version>
                     package manager: built-in npm|<npm|yarn>@<version>]
-            [default: <version>
-                binaries: [<binary name>]...
-                platform:
-                    runtime: node@<version>
-                    package manager: built-in npm|<npm|yarn>@<version>]
-            [fetched: <version>[, <version>...]]
+            [<version> (fetched)]
 ```
 
 <details><summary>Outside a project directory</summary>
@@ -385,37 +378,39 @@ $ volta list all --format=human
 User toolchain:
 
     Node runtimes:
-        default: v10.15.3
-        fetched: v8.16.0, v11.9.0, v12.2.0
+        v10.15.3 (default)
+        v8.16.0 (fetched)
+        v11.9.0 (fetched)
+        v12.2.0 (fetched)
 
     Package managers:
         Yarn:
-            default: v1.16.0
-            fetched: v1.12.3
+            v1.16.0 (default)
+            v1.12.3 (fetched)
 
     Packages:
         create-react-app:
-            default: v3.0.1
+            v3.0.1 (default)
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
         ember-cli:
-            default: v3.10.0
+            v3.10.0 (default)
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            fetched: v3.8.2
+            v3.8.2 (fetched)
         typescript:
-            default: v3.0.3
+            v3.0.3 (default)
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            fetched: v3.4.5
+            v3.4.5 (fetched)
         yarn-deduplicate:
-            fetched: v1.1.1
+            v1.1.1 (fetched)
 ```
 
 </details>
@@ -427,81 +422,87 @@ $ volta list all --format=human
 User toolchain:
 
     Node runtimes:
-        current: v8.16.0 (from ~/node-only/package.json)
-        default: v10.15.3
-        fetched: v11.9.0, v12.2.0
+        v8.16.0 (current @ ~/node-only/package.json)
+        v10.15.3 (default)
+        v11.9.0 (fetched)
+        v12.2.0 (fetched)
 
     Package managers:
         Yarn:
-            default: v1.16.0
-            fetched: v1.12.3
+            v1.16.0 (default)
+            v1.12.3 (fetched)
 
     Packages:
         create-react-app:
-            default: v3.0.1
+            v3.0.1 (default)
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
         ember-cli:
-            default: v3.10.0
+            v3.10.0 (default)
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            fetched: v3.8.2
+            v3.8.2 (fetched)
         tsc:
-            default: v3.0.3
+            v3.0.3 (default)
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            fetched: v3.4.5
+            v3.4.5 (fetched)
         yarn-deduplicate:
-            fetched: v1.1.1
+            v1.1.1 (fetched)
 ```
 
 </details>
 
-<details><summary>In the <code>node-and-yarn</code> project</summary>
+<details><summary>In the <code>node-yarn-ember</code> project</summary>
 
 ```sh
 $ volta list all --format=human
 User toolchain:
 
     Node runtimes:
-        current: v12.2.0 (from ~/node-and-yarn/project.json)
-        default: v10.15.3
-        fetched: v8.16.0, v11.9.0
+        v12.2.0 (current @ ~/node-yarn-ember/project.json)
+        v10.15.3 (default)
+        v8.16.0 (fetched)
+        v11.9.0 (fetched)
 
     Package managers:
         Yarn:
-            default: v1.16.0
-            current: v1.12.3 (from ~/node-and-yarn/project.json)
+            v1.16.0 (default)
+            v1.12.3 (current @ ~/node-yarn-ember/project.json)
 
     Packages:
         create-react-app:
-            default: v3.0.1
+            v3.0.1 (default)
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
         ember-cli:
-            default: v3.10.0
+            v3.10.0 (default)
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            fetched: v3.8.2
+            v3.8.2 (current @ ~/node-yarn-ember/project.json)
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0 (@ ~/node-yarn-ember/project.json)
+                    package manager: yarn@v1.12.3 (@ ~/node-yarn-ember/project.json)
         tsc:
-            default: v3.0.3
+            v3.0.3 (default)
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            fetched: v3.4.5
+            v3.4.5 (fetched)
         yarn-deduplicate:
-            fetched: v1.1.1
+            v1.1.1 (fetched)
 ```
 
 </details>
@@ -545,7 +546,7 @@ $ volta list all --format=plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
-runtime node@v8.16.0 (current @ ~/node-only/package.json)
+runtime node@v8.16.0 (@ ~/node-only/package.json)
 package-manager yarn@v1.16.0 (default)
 package-manager yarn@v1.12.3
 package create-react-app@v3.0.1 / create-react-app / node@v12.2.0 npm@built-in (default)
@@ -558,19 +559,19 @@ package yarn-deduplicate@v1.1.1 (fetched)
 
 </details>
 
-<details><summary>In the <code>node-and-yarn</code> project</summary>
+<details><summary>In the <code>node-yarn-ember</code> project</summary>
 
 ```sh
 $ volta list all --format=plain
-runtime node@v12.2.0 (current @ ~/node-and-yarn/project.json)
+runtime node@v12.2.0 (@ ~/node-yarn-ember/project.json)
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
 runtime node@v8.16.0
 package-manager yarn@v1.16.0 (default)
-package-manager yarn@v1.12.3 (current @ ~/node-and-yarn/project.json)
+package-manager yarn@v1.12.3 (@ ~/node-yarn-ember/project.json)
 package create-react-app@v3.0.1 / create-react-app / node@v12.2.0 npm@built-in (default)
 package ember-cli@v3.10.0 / ember / node@v12.2.0 npm@built-in (default)
-package ember-cli@v3.8.2 (fetched)
+package ember-cli@v3.8.2 / ember / node@v12.2.0 yarn@v1.12.3 (@ ~/node-yarn-ember/project.json)
 package typescript@v3.4.5 (fetched)
 package typescript@v3.0.3 / tsc, tsserver / node@v12.2.0 npm@built-in (default)
 package yarn-deduplicate@v1.1.1 (fetched)
@@ -589,7 +590,7 @@ The basic format is:
 ```sh
 volta list <package> --format=human
 
-    [default: <version>|current: <version>(from @ <project path>)
+    [default: <version>|current: <version>(@ <project path>)
         binaries: [<binary name>]...
         platform:
             runtime: node@<version>
@@ -640,7 +641,7 @@ The basic format is:
 volta list <tool> --format=human
 tool <tool> available from package:
 
-    [default: <package>@<version>|current <package>@<version> (@ <project path>)]
+    <package>@<version> (default|current @ <project path>)
         platform:
             runtime: node@<version>
             package manager: built-in npm|<npm|yarn>@<version>
@@ -652,7 +653,7 @@ For the TypeScript config specified in the canonical example:
 volta list tsc --format=human
 tool tsc available from:
 
-    default: typescript@v3.0.3
+    typescript@v3.0.3 (default)
         platform:
             runtime: node@v12.2.0
             package manager: built-in npm
@@ -704,7 +705,7 @@ Volta 0.5.2
 Currently active tools:
 
     Node: v8.16.0 (default)
-    Yarn: v1.12.3 (from ~/node-and-yarn/package.json)
+    Yarn: v1.12.3 (current @ ~/node-yarn-ember/package.json)
     Package binaries available:
         create-react-app, ember, tsc, tsserver
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -43,10 +43,12 @@ These commands represent the Volta ideas of the user's *toolchain*, including *d
 These ideas already exist implicitly in Volta's vocabulary. Introducing `list` provides a specific place for users to see what the terms mean and how they are employed. Indeed, one of the primary benefits of the `list` command is that it provides a point where the Volta model—as distinct from e.g. the nvm or nodenv models—can be *made explicit* and thereby taught to users.
 
 ## Why `list`?
+[why-list]: #why-list
 
-Potential options include `list`, `ls`, `tools`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, `list` is the most flexible in terms of allowing variants to let the user describe *parts* of their toolchain as desired. It is also is a very common name for this operation in other tools (see the survey below). Additionally, choosing `list` as the primary name of the command does not preclude adding aliases for common operations later.
+Potential options include `list`, `ls`, `tools`, `toolchain`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, `list` is the most flexible in terms of allowing variants to let the user describe *parts* of their toolchain as desired. It is also is a very common name for this operation in other tools (see the survey below). Additionally, choosing `list` as the primary name of the command does not preclude adding aliases for common operations later.
 
-### Survey details
+## Prior art
+[prior-art]: #prior-art
 
 A brief survey of the broader developer ecosystem indicates that `list` is by far the most common (sub)command used in CLI tools for listing installed versions of tools. The only major exception is `nodenv`, which (reasonably) seems to treat the "list" action as implicit in the user's intention, given that nodenv serves *only* to manage specific versions of Node. `nvm` uses `ls` and `ls-remote`, which are standard Unix shortenings of "list."
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -63,9 +63,45 @@ They also have two projects with the following pins:
     }
     ```
 
-## Overview of CLI commands
+## CLI Command
 
-Top-level command: show the current to
+### `volta list` (no flags)
+
+#### Pretty
+
+The format is:
+
+```sh
+$ volta list
+⚡️ Currently active toolchain:
+
+    Node: version [(default|project)]
+    <packager>: <built-in|version> [(default|project)]]
+    Tool binaries available:
+        <comma separated list|NONE>
+
+See options for more detailed reports by running `volta list --help`.
+```
+
+<details><summary>Outside a project</summary>
+
+```sh
+$ volta list
+⚡️ Currently active toolchain:
+
+    Node: v8.16.0 (default)
+    Yarn: v1.12.3 (default)
+    Tool binaries available:
+        create-react-app, ember, tsc, tsserver, yarn-deduplicate
+
+See options for more detailed reports by running `volta list --help`.
+```
+
+</details>
+
+<details><summary>In the `node-only` project</summary>
+
+<b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436)
 
 ```sh
 $ volta list
@@ -79,7 +115,23 @@ $ volta list
 See options for more detailed reports by running `volta list --help`.
 ```
 
-Show all available tools, including binaries, with `list --all`:
+</details>
+
+<details><summary>In the <code>node-and-yarn</code> project</summary>
+
+```sh
+$ volta list
+⚡️ Currently active toolchain:
+
+    Node: v12.2.0 (from `~/pinned/node-and-yarn/package.json`)
+    Yarn: v1.16.0 (from `~/pinned/node-and-yarn/package.json`)
+    Tool binaries available:
+        create-react-app, ember, tsc, tsserver, yarn-deduplicate
+
+See options for more detailed reports by running `volta list --help`.
+```
+    
+</details>
 
 ```sh
 $ volta list --all

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -885,7 +885,7 @@ The basic format is:
 
 ```sh
 $ volta list <tool> --format=human
-⚡️ tool <tool> available from:
+⚡️ tool `<tool>` available from:
 
     <package>@<version> [(default|current @ <project path>)]
         platform:
@@ -897,7 +897,7 @@ For the TypeScript config specified in the canonical example:
 
 ```sh
 $ volta list tsc --format=human
-⚡️ tool tsc available from:
+⚡️ tool `tsc` available from:
 
     typescript@v3.4.5
         platform:

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -129,9 +129,9 @@ Survey details:
 
 The `volta list` command supports four *variants*:
 
-- **`volta list`:** comparable to the existing `volta current`, but expanded. Shows not only the user’s current runtime but also their current packager and any available tool binaries, as well as explanation of why the current values are what they are.
+- **`volta list`:** comparable to the existing `volta current`, but expanded. Shows not only the user’s current runtime but also their current package manager and any available tool binaries, as well as explanation of why the current values are what they are.
 
-- **`volta list all`:** shows every fetched runtime, packager, and tool version along with the binaries available for each tool. Also indicates of whether each is a default or is set for a project in the user’s current working directory.
+- **`volta list all`:** shows every fetched runtime, package manager, and tool version along with the binaries available for each tool. Also indicates of whether each is a default or is set for a project in the user’s current working directory.
 
 - **`volta list <package>`:** shows a subset of the output from `all`, scoped to the information for a specific package which has been fetched to the user’s inventory.
 
@@ -141,12 +141,12 @@ The command also supports (initially) two *output modes*: *human-friendly* (`hum
 
 ## Information supplied by the command
 
-The `volta list` command always prints the following information for a set of runtimes, packagers, and tools:
+The `volta list` command always prints the following information for a set of runtimes, package managers, and tools:
 
 - name
 - version
 - whether it is the user's default toolchain or a project version
-- for tools, the associated runtime and packager versions
+- for tools, the associated runtime and package manager versions
 
 ## Flags
 
@@ -163,11 +163,11 @@ The two are *optional* and *mutually exclusive*.
 
 ### Output modes
 
-The tool will support multiple modes (two initially), which include exactly the same information but presented in different human- or machine-friendly formats. All modes include the same information for runtimes, packagers, and tools: name, version, whether it is a user- or project-specified version, and (for tools) the Node version and packager (i.e. platform).
+The tool will support multiple modes (two initially), which include exactly the same information but presented in different human- or machine-friendly formats. All modes include the same information for runtimes, package managers, and tools: name, version, whether it is a user- or project-specified version, and (for tools) the Node version and package manager (i.e. platform).
 
-- "human" mode, the default if the context is a user-facing terminal; also invokable with `--format=human` in any context. An indented listing of the user's current runtime, packager (if specified), and any installed binaries. See the detailed sections below for examples of the format.
+- "human" mode, the default if the context is a user-facing terminal; also invokable with `--format=human` in any context. An indented listing of the user's current runtime, package manager (if specified), and any installed binaries. See the detailed sections below for examples of the format.
 
-- "plain" mode, the default if the context is not a user-facing terminal (e.g. when piped into another command); also invokable with `--format=plain` in any context. A simple plain text format which prints a line per runtime, packager, or tool, with space-separated output on each line.
+- "plain" mode, the default if the context is not a user-facing terminal (e.g. when piped into another command); also invokable with `--format=plain` in any context. A simple plain text format which prints a line per runtime, package manager, or tool, with space-separated output on each line.
 
     - runtimes:
 
@@ -175,10 +175,10 @@ The tool will support multiple modes (two initially), which include exactly the 
         runtime node@<version>
         ```
 
-    - packagers:
+    - package managers:
 
         ```
-        packager (yarn|npm)@<version>
+        packager-manager (yarn|npm)@<version>
         ```
 
     - tools: 
@@ -291,13 +291,13 @@ $ volta list --format=human
 ⚡️ Currently active tools:
 
     Node runtime: v12.2.0 (current @ ~/node-and-yarn/package.json)
-    Packager: Yarn: v1.16.0 (current @ ~/node-and-yarn/package.json)
+    Package manager: Yarn: v1.16.0 (current @ ~/node-and-yarn/package.json)
     Tool binaries available:
         create-react-app, ember, tsc, tsserver
 
 See options for more detailed reports by running `volta list --help`.
 ```
-    
+
 </details>
 
 #### Plain
@@ -307,7 +307,7 @@ The format is:
 ```sh
 $ volta list --format=plain
 runtime node@<version> (default|current @ <project path>)
-packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
+package-manager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 ```
 
 <details><summary>Outside a project</summary>
@@ -315,7 +315,7 @@ packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 ```sh
 $ volta list --format=plain
 runtime node@v10.15.3 (default)
-packager yarn@v1.12.3 (default)
+package-manager yarn@v1.12.3 (default)
 ```
 
 </details>
@@ -327,7 +327,7 @@ packager yarn@v1.12.3 (default)
 ```sh
 $ volta list --format=plain
 runtime node@v8.16.0 (~/node-only/package.json)
-packager yarn@v1.12.3 (default)
+package-manager yarn@v1.12.3 (default)
 ```
 
 </details>
@@ -337,7 +337,7 @@ packager yarn@v1.12.3 (default)
 ```sh
 $ volta list --format=plain
 runtime node@v12.2.0 (~/node-and-yarn/package.json)
-packager yarn@v1.16.0 (~/node-and-yarn/package.json)
+package-manager yarn@v1.16.0 (~/node-and-yarn/package.json)
 ```
 
 </details>
@@ -354,18 +354,18 @@ $ volta list all --format=human
 
     Node runtimes:
         <version> [(default|current @ <project path>)]
-    
-    Packagers:
+
+    Package managers:
         (Yarn|npm):
             <version> [(default|current @ <project path>)]
-    
+
     Tools:
         <package name>
             <version> [(default|current @ <project path>)]
                 binaries: [<binary name>]...
                 platform:
                     runtime: node@<version>
-                    packager: built-in npm|<npm|yarn>@<version>
+                    package manager: built-in npm|<npm|yarn>@<version>
 ```
 
 <details><summary>Outside a project directory</summary>
@@ -379,41 +379,41 @@ $ volta list all --format=human
         v11.9.0
         v10.15.3 (default)
         v8.16.0
-    
-    Packagers:
+
+    Package managers:
         Yarn:
             v1.16.0 (default)
             v1.12.3
-    
+
     Tools:
         create-react-app:
             v3.0.1 (default)
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         ember-cli:
             v3.10.0 (default)
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
             v3.8.2
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         typescript:
             v3.4.5
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
             v3.0.3 (default)
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         yarn-deduplicate:
             v1.1.1
                 binaries: yarn-deduplicate
@@ -432,41 +432,41 @@ $ volta list all --format=human
         v11.9.0
         v10.15.3 (default)
         v8.16.0 (current)
-    
-    Packagers:
+
+    Package managers:
         Yarn:
             v1.16.0 (default)
             v1.12.3
-    
+
     Tools:
         create-react-app:
             v3.0.1 (default)
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         ember-cli:
             v3.10.0 (default)
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
             v3.8.2
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         tsc:
             v3.4.5
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
             v3.0.3 (default)
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         yarn-deduplicate:
             v1.1.1
                 binaries: yarn-deduplicate
@@ -485,41 +485,41 @@ $ volta list all --format=human
         v11.9.0
         v10.15.3 (default)
         v8.16.0
-    
-    Packagers:
+
+    Package managers:
         Yarn:
             v1.16.0 (default)
             v1.12.3 (current @ ~/node-and-yarn/project.json)
-    
+
     Tools:
         create-react-app:
             v3.0.1 (default)
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         ember-cli:
             v3.10.0 (default)
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
             v3.8.2
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         tsc:
             v3.4.5
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
             v3.0.3 (default)
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
-                    packager: built-in npm
+                    package manager: built-in npm
         yarn-deduplicate:
             v1.1.1
                 binaries: yarn-deduplicate
@@ -534,7 +534,7 @@ The basic format is:
 ```sh
 $ volta list all --format=plain
 runtime node@<version> [(default|current @ <project path>)]
-packager <packager>@<version> [(default|current @ <project path>)]
+package-manager <packager>@<version> [(default|current @ <project path>)]
 tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
 ```
 
@@ -546,8 +546,8 @@ runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
 runtime node@v8.16.0
-packager yarn@v1.16.0 (default)
-packager yarn@v1.12.3
+package-manager yarn@v1.16.0 (default)
+package-manager yarn@v1.12.3
 tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
 tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
 tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
@@ -568,8 +568,8 @@ runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
 runtime node@v8.16.0 (current @ ~/node-only/package.json)
-packager yarn@v1.16.0 (default)
-packager yarn@v1.12.3
+package-manager yarn@v1.16.0 (default)
+package-manager yarn@v1.12.3
 tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
 tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
 tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
@@ -590,8 +590,8 @@ runtime node@v12.2.0 (current @ ~/node-and-yarn/project.json)
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
 runtime node@v8.16.0
-packager yarn@v1.16.0 (default)
-packager yarn@v1.12.3 (current @ ~/node-and-yarn/project.json)
+package-manager yarn@v1.16.0 (default)
+package-manager yarn@v1.12.3 (current @ ~/node-and-yarn/project.json)
 tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
 tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
 tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
@@ -600,222 +600,6 @@ tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool yarn-deduplicate / yarn-deduplicate@v1.1.1
-```
-
-</details>
-
-### `volta list node`
-
-List all fetched Node runtimes.
-
-#### Human
-
-The basic format is:
-
-```sh
-$ volta list node --format=human
-⚡️ Node runtimes in your toolchain:
-
-    <version> [(default|current @ <project path>)]
-```
-
-If the user has no Node runtimes installed:
-
-```sh
-$ volta list node --format=human
-⚡️ No Node runtimes installed!
-
-You can install a runtime by running `volta install node`. See `volta help install` for
-details and more options.
-```
-
-<details><summary>Outside a project</summary>
-
-```sh
-$ volta list node --format=human
-⚡️ Node runtimes in your toolchain:
-
-    v12.2.0
-    v11.9.0
-    v10.15.3 (default)
-    v8.16.0
-```
-
-</details>
-
-<details><summary>In the `node-only` project</summary>
-
-```sh
-$ volta list node --format=human
-⚡️ Node runtimes in your toolchain:
-
-    v12.2.0
-    v11.9.0
-    v10.15.3 (default)
-    v8.16.0 (current @ ~/node-only/package.json)
-```
-
-</details>
-
-<details><summary>In the `node-and-yarn` project</summary>
-
-```sh
-$ volta list node --format=human
-⚡️ Node runtimes in your toolchain:
-
-    v12.2.0 (current @ ~/node-and-yarn/package.json)
-    v11.9.0
-    v10.15.3 (default)
-    v8.16.0
-```
-
-</details>
-
-#### Plain
-
-The basic format is:
-
-```sh
-$ volta list node --format=plain
-runtime node@<version> [(default|current @ <project path>)]
-```
-
-If the user has no Node runtimes installed, print nothing.
-
-<details><summary>Outside a project</summary>
-
-```sh
-$ volta list node --format=human
-runtime node@v12.2.0
-runtime node@v11.9.0
-runtime node@v10.15.3 (default)
-runtime node@v8.16.0
-```
-
-</details>
-
-<details><summary>In the `node-only` project</summary>
-
-```sh
-$ volta list node --format=human
-runtime node@v12.2.0
-runtime node@v11.9.0
-runtime node@v10.15.3 (default)
-runtime node@v8.16.0 (current @ ~/node-only/package.json)
-```
-
-</details>
-
-<details><summary>In the `node-and-yarn` project</summary>
-
-```sh
-$ volta list node --format=human
-runtime node@v12.2.0 (current @ ~/node-and-yarn/package.json)
-runtime node@v11.9.0
-runtime node@v10.15.3 (default)
-runtime node@v8.16.0
-```
-
-</details>
-
-### `volta list <npm|yarn>`
-
-List all fetched npm or Yarn versions. (Currently only Yarn is implemented.)
-
-#### Human
-
-The basic format is:
-
-```sh
-$ volta list <npm|yarn> --format=human
-⚡️ <npm|Yarn> versions in your toolchain:
-
-    <version> [(default|current @ <project path>)]
-```
-
-If the user has no packagers installed:
-
-```sh
-$ volta list <npm|yarn> --format=human
-⚡️ No <npm|Yarn> versions installed.
-
-You can install a Yarn version by running `volta install yarn`. See `volta help install` for
-details and more options.
-```
-
-<details><summary>Outside a project</summary>
-
-```sh
-$ volta list yarn --format=human
-⚡️ Yarn versions in your toolchain:
-
-    v1.16.0
-    v1.12.3 (default)
-```
-
-</details>
-
-<details><summary>In the `node-only` project</summary>
-
-```sh
-$ volta list yarn --format=human
-⚡️ Yarn versions in your toolchain:
-
-    v1.16.0
-    v1.12.3 (default)
-```
-
-</details>
-
-<details><summary>In the `node-and-yarn` project</summary>
-
-```sh
-$ volta list yarn --format=human
-⚡️ Yarn versions in your toolchain:
-
-    v1.16.0 (current @ ~/node-and-yarn/package.json)
-    v1.12.3 (default)
-```
-
-</details>
-
-#### Plain
-
-The basic format is:
-
-```sh
-$ volta list <npm|yarn> --format=plain
-packager <packager>@<version> [(default|current @ <project path>)]
-```
-
-If the user has no packagers installed, output nothing.
-
-<details><summary>Outside a project</summary>
-
-```sh
-$ volta list yarn --format=plain
-packager yarn@v1.16.0
-packager yarn@v1.12.3 (default)
-```
-
-</details>
-
-<details><summary>In the `node-only` project</summary>
-
-```sh
-$ volta list yarn --format=plain
-packager yarn@v1.16.0
-packager yarn@v1.12.3 (default)
-```
-
-</details>
-
-<details><summary>In the `node-and-yarn` project</summary>
-
-```sh
-$ volta list yarn --format=plain
-packager yarn@v1.16.0 (current @ ~/node-and-yarn/package.json)
-packager yarn@v1.12.3 (default)
 ```
 
 </details>
@@ -829,33 +613,31 @@ List all fetched versions of a specific package, along with its associated binar
 The basic format is:
 
 ```sh
-$ volta list <package> --format=human
-⚡️ `<package>` versions in your toolchain:
+volta list <package> --format=human
 
     <version> [(default|current @ <project path>)]
         binaries: [<binary name>]...
         platform:
             runtime: node@<version>
-            packager: built-in npm|<npm|yarn>@<version>
+            package manager: built-in npm|<npm|yarn>@<version>
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-$ volta list typescript --format=human
-⚡️ `typescript` versions in your toolchain:
+volta list package typescript --format=human
 
     v3.4.5
         binaries: tsc, tsserver
         platform:
             runtime: node@v12.2.0
-            packager: built-in npm
+            package manager: built-in npm
 
     v3.0.3 (default)
         binaries: tsc, tsserver
         platform:
             runtime: node@v12.2.0
-            packager: built-in npm
+            package manager: built-in npm
 ```
 
 #### Plain
@@ -863,14 +645,14 @@ $ volta list typescript --format=human
 The basic format is:
 
 ```sh
-$ volta list <package> --format=plain
+volta list <package> --format=plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-$ volta list typescript --format=plain
+volta list typescript --format=plain
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
@@ -884,30 +666,30 @@ tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 The basic format is:
 
 ```sh
-$ volta list <tool> --format=human
-⚡️ tool `<tool>` available from:
+volta list <tool> --format=human
+⚡️ tool <tool> available from:
 
     <package>@<version> [(default|current @ <project path>)]
         platform:
             runtime: node@<version>
-            packager: built-in npm|<npm|yarn>@<version>
+            package manager: built-in npm|<npm|yarn>@<version>
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-$ volta list tsc --format=human
-⚡️ tool `tsc` available from:
+volta list tsc --format=human
+⚡️ tool tsc available from:
 
     typescript@v3.4.5
         platform:
             runtime: node@v12.2.0
-            packager: built-in npm
+            package manager: built-in npm
 
     typescript@v3.0.3 (default)
         platform:
             runtime: node@v12.2.0
-            packager: built-in npm
+            package manager: built-in npm
 ```
 
 #### Plain
@@ -915,14 +697,14 @@ $ volta list tsc --format=human
 The basic format is:
 
 ```sh
-$ volta list <tool> --format=plain
+volta list <tool> --format=plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-$ volta list tsc
+volta list tsc
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 ```

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -515,7 +515,7 @@ The basic format is:
 $ volta list all --format=plain
 runtime node@<version> [(default|current @ <project path>)]
 package-manager <packager>@<version> [(default|current @ <project path>)]
-package <package>@<version> / [<tool>, ...] / <npm|yarn>@<built-in|version> (default|current @ <path>)
+package <package>@<version> / [<tool>, ...] / node@<version> <npm|yarn>@<built-in|version> (default|current @ <path>)
 package <name>@<version> (fetched)
 ```
 
@@ -661,18 +661,18 @@ tool tsc available from:
 
 #### Plain
 
-The basic format is the same as the format for packages, but `fetched` can never appear (under the current implementation limitations):
+The basic format is similar to the format for packages, but `fetched` can never appear (under the current implementation limitations):
 
 ```sh
 volta list <tool> --format=plain
-package <package>@<version> / [<tool>, ...] / <npm|yarn>@<built-in|version> (default|current @ <path>)
+tool <tool> / <package>@<version> <npm|yarn>@<built-in|version> (default|current @ <path>)
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
 volta list tsc
-package typescript@v3.0.3 / tsc, tsserver / node@12.2.0 npm@built-in (default)
+tool tsc / typescript@v3.0.3 / node@12.2.0 npm@built-in (default)
 ```
 
 ## Deprecating `volta current`

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -463,54 +463,20 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (defau
 
 ```sh
 $ volta list --all
-⚡️ User toolchain:
-
-    Node runtimes:
-        v12.2.0 (`~/node-and-yarn/project.json`)
-        v11.9.0
-        v10.15.3 (default)
-        v8.16.0
-    
-    Packagers:
-        Yarn:
-            v1.16.0 (default)
-            v1.12.3 (`~/node-and-yarn/project.json`)
-    
-    Tools:
-        create-react-app:
-            v3.0.1 (default)
-                binaries: create-react-app
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-        ember-cli:
-            v3.10.0 (default)
-                binaries: ember
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-            v3.8.2
-                binaries: ember
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-        tsc:
-            v3.4.5
-                binaries: tsc, tsserver
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-            v3.0.3 (default)
-                binaries: tsc, tsserver
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-        yarn-deduplicate:
-            v1.1.1 (default)
-                binaries: yarn-deduplicate
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
+runtime node@v12.2.0 (current@~/node-and-yarn/project.json)
+runtime node@v11.9.0
+runtime node@v10.15.3 (default)
+runtime node@v8.16.0
+packager yarn@v1.16.0 (default)
+packager yarn@v1.12.3 (current@~/node-and-yarn/project.json)
+tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
+tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
+tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
+tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
+tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
+tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
+tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (default)
 ```
 
 </details>

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -100,14 +100,17 @@ Survey details:
 
 The `volta list` command supports four *variants*:
 
-- with no flags: `volta list` – comparable to the existing `volta current`, but expanded to show not only the user’s current runtime but also their current packager and any available tool binaries, as well as explanation of why the current values are what they are
-- with `--all`: `volta list --all` – shows every fetched runtime, packager, and tool version, along with the binaries available for each tool, and an indication of whether each is a default or is set for a project in the user’s current working directory
-- with `--package`: `volta list --package=<package>` – shows a subset of the output from `--all`, scoped to the information for a specific package which has been fetched to the user’s inventory one or more times
-- with `--tool`: `volta list --tool=<tool>` – shows a subset of the output from `--all`, scoped to the information for a specific tool which has been fetched to the user’s inventory one or more times; like `--package` but if a package has more than one tool associated with it, only the specified tool will be shown
+- **no subcommand:** `volta list` – comparable to the existing `volta current`, but expanded to show not only the user’s current runtime but also their current packager and any available tool binaries, as well as explanation of why the current values are what they are
+
+- **`--all`:** `volta list --all` – shows every fetched runtime, packager, and tool version, along with the binaries available for each tool, and an indication of whether each is a default or is set for a project in the user’s current working directory
+
+- **`package`:** `volta list package <package>` – shows a subset of the output from `--all`, scoped to the information for a specific package which has been fetched to the user’s inventory one or more times
+
+- **`tool`:** `volta list tool <tool>` – shows a subset of the output from `--all`, scoped to the information for a specific tool which has been fetched to the user’s inventory one or more times; like `package` but if a package has more than one tool associated with it, only the specified tool will be shown
 
 It also supports (initially) two *output modes*: *human-friendly* (`human`) and *machine-friendly* (`plain`).
 
-## Command Output
+## Information supplied by the command
 
 The `volta list` command always prints the following information for a set of runtimes, packagers, and tools:
 
@@ -568,7 +571,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 
 </details>
 
-### `volta list --package=<package>`
+### `volta list package <package>`
 
 List all fetched versions of a specific package, along with its associated binaries.
 
@@ -577,7 +580,7 @@ List all fetched versions of a specific package, along with its associated binar
 The basic format is:
 
 ```sh
-volta list --package=<package> --human
+volta list package <package> --human
 
     <version> [(default|current @ <project path>)]
         binaries: [<binary name>]...
@@ -589,7 +592,7 @@ volta list --package=<package> --human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list --package=typescript --human
+volta list package typescript --human
 
     v3.4.5
         binaries: tsc, tsserver
@@ -609,28 +612,28 @@ volta list --package=typescript --human
 The basic format is:
 
 ```sh
-volta list --package=<package> --plain
+volta list package <package> --plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list --package=typescript --plain
+volta list package typescript --plain
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 ```
 
-### `volta list --tool=<tool>`
+### `volta list tool <tool>`
 
 #### Human
 
 The basic format is:
 
 ```sh
-volta list --tool=<tool> --human
+volta list tool <tool> --human
 ⚡️ tool <tool> available from:
 
     <package>@<version> [(default|current @ <project path>)]
@@ -642,7 +645,7 @@ volta list --tool=<tool> --human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list --tool=tsc --human
+volta list tool tsc --human
 ⚡️ tool tsc available from:
 
     typescript@v3.4.5
@@ -661,14 +664,14 @@ volta list --tool=tsc --human
 The basic format is:
 
 ```sh
-volta list --tool=<tool> --plain
+volta list tool <tool> --plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list --tool=tsc
+volta list tool tsc
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 ```
@@ -708,6 +711,8 @@ This section discusses the tradeoffs considered in this proposal. This must incl
     And how should that be presented in `plain` vs. `human` mode? Should there be any differences between `plain` and `human` for the bare command (as in the current design)?
 
 - How should the current version be identified? It is currently marked with `(current @ <path>)`. Should this be `(from <path>)` or some other design?
+
+- Should the `list` command accept flags to narrow the search instead of subcommands, e.g. `volta list --node`, `volta list --yarn`, `volta list --package=typescript`, etc.?
 
 <!-- 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -8,6 +8,28 @@
 
 Add an informational command, `volta list`, replacing the `volta current` command and expanding on its capabilities. The `list` command will allow users to see their default and project-specific toolchains, and will support both human-friendly output and a tool-friendly output.
 
+- [Summary](#summary)
+- [Motivation](#motivation)
+- [Pedagogy](#pedagogy)
+    - [Why `list`?](#why-list)
+    - [Prior art](#prior-art)
+- [Details](#details)
+    - [Information supplied by the command](#information-supplied-by-the-command)
+    - [Output modes](#output-modes)
+    - [Detailed Command Output](#detailed-command-output)
+        - [Assumed Configuration](#assumed-configuration)
+        - [`volta list` (no flags)](#volta-list-no-flags)
+        - [`volta list --all`](#volta-list---all)
+        - [`volta list package <package>`](#volta-list-package-package)
+        - [`volta list tool <tool>`](#volta-list-tool-tool)
+    - [Deprecating `volta current`](#deprecating-volta-current)
+- [Critique](#critique)
+    - [Use another command name](#use-another-command-name)
+    - [Use shorthands instead of `list`](#use-shorthands-instead-of-list)
+    - [Keep `volta current` as an alias for `volta list`](#keep-volta-current-as-an-alias-for-volta-list)
+    - [Do not add `list`](#do-not-add-list)
+- [Unresolved questions](#unresolved-questions)
+
 # Motivation
 [motivation]: #motivation
 
@@ -19,14 +41,14 @@ Users of Volta currently have no way to get the answers to the following questio
 - What binaries are supplied by a given package which has been installed?
 - What Node version and packager are used by a given tool binary?
 
-The only tooling available to answer *any* of these question presently is the `volta current` command, which prints exactly and only the version of Node itself which will be executed in the user’s current directory. Users wanting to answer these questions today must resort to poking through the `~/.volta` directory, and its internals are *not* public API, so any tooling a user might put in place around that would be subject to breakage between versions.
+The only tooling available to answer *any* of these questions are the `volta current` and `volta which` commands. `volta current` prints exactly and only the version of Node itself which will be executed in the user’s current directory. `volta which` answers the question for any single item in the user's toolchain, but only by parsing a path. Users must resort to poking through the `~/.volta` directory to answer these questions, and its internals are *not* public API. Thus, any tooling a user might build around the directory could break between versions.
 
-Adding a `volta list` command designed to address all of these needs allows users to get and use the information however they need. Adding it with both human- and tool-friendly output formats makes for a better user-experience: the default output will make it easy for people to *read*, and the machine-readable formats will make it easy for people to build *tools* around.
+Adding a `volta list` command addresses this need. Adding it with both human- and tool-friendly output formats makes for a better user-experience: the default output will make it easy for people to *read*, and the machine-readable formats will make it easy for people to build *tools* around.
 
 # Pedagogy
 [pedagogy]: #pedagogy
 
-We introduce a `list` command, which lets users get a description of their Volta environment: the currently-active items in their toolchain and the reason those items are currently active, and the total set of available tools on their system.
+We introduce a `list` command, which lets users get a description of their Volta environment: the currently-active items in their toolchain, the reason those items are currently active, and the total set of available tools on their system.
 
 - To get the currently-active runtime, packager, and available binaries, the user can run `volta list`.
 
@@ -45,12 +67,12 @@ These ideas already exist implicitly in Volta's vocabulary. Introducing `list` p
 ## Why `list`?
 [why-list]: #why-list
 
-Potential options include `list`, `ls`, `tools`, `toolchain`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, `list` is the most flexible in terms of allowing variants to let the user describe *parts* of their toolchain as desired. It is also is a very common name for this operation in other tools (see the survey below). Additionally, choosing `list` as the primary name of the command does not preclude adding aliases for common operations later.
+Potential options include `list`, `ls`, `tools`, `toolchain`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, `list` is the most flexible, supplying variants to let the user describe *parts* of their toolchain as desired. It is also is a very common name for this operation in other tools (see the survey below). Additionally, choosing `list` as the primary name of the command does not preclude adding aliases for common operations later.
 
 ## Prior art
 [prior-art]: #prior-art
 
-A brief survey of the broader developer ecosystem indicates that `list` is by far the most common (sub)command used in CLI tools for listing installed versions of tools. The only major exception is `nodenv`, which (reasonably) seems to treat the "list" action as implicit in the user's intention, given that nodenv serves *only* to manage specific versions of Node. `nvm` uses `ls` and `ls-remote`, which are standard Unix shortenings of "list."
+A brief survey of the broader developer ecosystem indicates that `list` is by far the most common (sub)command used in CLI tools for listing installed versions of tools. The only major exception is `nodenv`, which (reasonably) seems to treat the "list" action as implicit in the user's intention. However, this is clearer for nodenv because it *only* manages specific versions of Node. `nvm` uses `ls` and `ls-remote`, which are standard Unix shortenings of "list."
 
 Survey details:
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -6,7 +6,7 @@
 # Summary
 [summary]: #summary
 
-Add an informational command, `volta list`, replacing the `volta current` command and expanding on its capabilities. The `list` command will allow users to see their default and project-specific toolchains, and will support both pretty-printed user-facing output and at least one mode of tool-friendly output.
+Add an informational command, `volta list`, replacing the `volta current` command and expanding on its capabilities. The `list` command will allow users to see their default and project-specific toolchains, and will support both human-friendly output and a tool-friendly output.
 
 # Motivation
 [motivation]: #motivation
@@ -67,7 +67,7 @@ They also have two projects with the following pins:
 
 ### `volta list` (no flags)
 
-#### Pretty
+#### Human
 
 The format is:
 
@@ -135,7 +135,7 @@ See options for more detailed reports by running `volta list --help`.
 
 ### `volta list --all`
 
-#### Pretty
+#### Human
 
 The basic format is:
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -831,7 +831,8 @@ List all fetched versions of a specific package, along with its associated binar
 The basic format is:
 
 ```sh
-volta list <package> --format=human
+$ volta list <package> --format=human
+⚡️ `<package>` versions in your toolchain:
 
     <version> [(default|current @ <project path>)]
         binaries: [<binary name>]...
@@ -843,7 +844,8 @@ volta list <package> --format=human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list package typescript --format=human
+$ volta list typescript --format=human
+⚡️ `typescript` versions in your toolchain:
 
     v3.4.5
         binaries: tsc, tsserver
@@ -863,14 +865,14 @@ volta list package typescript --format=human
 The basic format is:
 
 ```sh
-volta list <package> --format=plain
+$ volta list <package> --format=plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list typescript --format=plain
+$ volta list typescript --format=plain
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
@@ -884,7 +886,7 @@ tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 The basic format is:
 
 ```sh
-volta list <tool> --format=human
+$ volta list <tool> --format=human
 ⚡️ tool <tool> available from:
 
     <package>@<version> [(default|current @ <project path>)]
@@ -896,7 +898,7 @@ volta list <tool> --format=human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list tsc --format=human
+$ volta list tsc --format=human
 ⚡️ tool tsc available from:
 
     typescript@v3.4.5
@@ -915,14 +917,14 @@ volta list tsc --format=human
 The basic format is:
 
 ```sh
-volta list <tool> --format=plain
+$ volta list <tool> --format=plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list tsc
+$ volta list tsc
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 ```

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -39,9 +39,9 @@ It is not necessary to write the actual feature documentation in this section, b
 
 ## Why `list`?
 
-Potential options include something like `list`, `ls`, `tools`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, as the tool survey below indicates, `list` is by far the most common name for this operation among other tools, and it is also the most flexible in terms of allowing variants to let the user describe *parts* of their toolchain as desired.
+Potential options include something like `list`, `ls`, `tools`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, `list` is the most flexible in terms of allowing variants to let the user describe *parts* of their toolchain as desired. It is also is a very common name for this operation in other tools (see the survey below). Additionally, choosing `list` as the primary name of the command does not preclude adding aliases for common operations later.
 
-### Prior art
+### Survey details
 
 A brief survey of the broader developer ecosystem indicates that `list` is by far the most common (sub)command used in CLI tools for listing installed versions of tools. The only major exception is `nodenv`, which (reasonably) seems to treat the "list" action as implicit in the user's intention, given that nodenv serves *only* to manage specific versions of Node. `nvm` uses `ls` and `ls-remote`, which are standard Unix shortenings of "list."
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -544,7 +544,7 @@ The basic format is:
 
 ```sh
 volta list --tool=<tool> --human
-⚡️ tool tsc available from:
+⚡️ tool <tool> available from:
 
     <package>@<version> [(default|current @ <project path>)]
         platform:

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -98,40 +98,12 @@ Survey details:
 # Details
 [details]: #details
 
-## Example configuration
+There are variants of the command:
 
-Throughout, we will assume the user has the following configuration for illustrative purposes:
-
-- Node versions installed: v12.2.0, v11.9.0, v10.15.3 (default), v8.16.0
-- Yarn versions installed: v1.16.0, v1.12.3 (default)
-- Tools installed:
-    - ember-cli: v3.10.0 (default) on Node v12.2.0, v3.8.2 on Node v12.2.0, with binary `ember`
-    - typescript: v3.4.5 on Node v12.2.0, v3.0.3 (default) on Node v12.2.0, with binaries `tsc`, `tsserver`
-    - create-react-app: v3.0.1 (default) on Node v12.2.0, with binary `create-react-app`
-    - yarn-deduplicate: v1.1.1 on Node v12.2.0, with binary `yarn-deduplicate` (notice that this is not a *default*; assume the user ran `volta fetch` )
-
-They also have two projects with the following pins:
-
-- `~/node-only/package.json`:
-
-    ```json
-    {
-      "volta": {
-        "node": "v8.16.0",
-      }
-    }
-    ```
-
-- `~/node-and-yarn/package.json`:
-
-    ```json
-    {
-      "volta": {
-        "node": "v12.2.0",
-        "yarn": "v1.16.0"
-      }
-    }
-    ```
+- with no flags: `volta list` – comparable to the existing `volta current`, but expanded to show not only the user’s current runtime but also their current packager and any available tool binaries, as well as explanation of why the current values are what they are
+- with `--all`: `volta list --all` – shows every fetched runtime, packager, and tool version, along with the binaries available for each tool, and an indication of whether each is a default or is set for a project in the user’s current working directory
+- with `--package`: `volta list --package=<package>` – shows a subset of the output from `--all`, scoped to the information for a specific package which has been fetched to the user’s inventory one or more times
+- with `--tool`: `volta list --tool=<tool>` – shows a subset of the output from `--all`, scoped to the information for a specific tool which has been fetched to the user’s inventory one or more times; like `--package` but if a package has more than one tool associated with it, only the specified tool will be shown
 
 ## CLI Command Design
 
@@ -168,7 +140,46 @@ The tool will support multiple modes (two initially), which include exactly the 
 
 This RFC does not propose, but allows for the possibility of, a JSON mode (`--print=json`) or similar at a later time if that proves desirable.
 
-## CLI Command Variants
+Below, this design is worked out in detailed examples.
+
+### Assumed Configuration
+
+Throughout, we will assume the user has the following configuration for illustrative purposes:
+
+- Node versions installed: v12.2.0, v11.9.0, v10.15.3 (default), v8.16.0
+- Yarn versions installed: v1.16.0, v1.12.3 (default)
+- Tools installed:
+    - ember-cli, with binary `ember`:
+	    - v3.10.0 on Node v12.2.0 with built-in npm (default)
+	    - v3.8.2 on Node v12.2.0 with built-in npm
+    - typescript, with binaries `tsc`, `tsserver`:
+	    - v3.4.5 on Node v12.2.0 with built-in npm
+	    - v3.0.3 on Node v12.2.0 with built-in npm (default)
+    - create-react-app, with binary `create-react-app`: v3.0.1 on Node v12.2.0 with built-in npm (default)
+    - yarn-deduplicate, with binary `yarn-deduplicate`: v1.1.1 on Node v12.2.0 with built-in npm (notice that this is not a *default*; assume the user ran `volta fetch` )
+
+They also have two projects with the following pins:
+
+- `~/node-only/package.json`:
+
+    ```json
+    {
+      "volta": {
+        "node": "v8.16.0",
+      }
+    }
+    ```
+
+- `~/node-and-yarn/package.json`:
+
+    ```json
+    {
+      "volta": {
+        "node": "v12.2.0",
+        "yarn": "v1.16.0"
+      }
+    }
+    ```
 
 ### `volta list` (no flags)
 
@@ -183,7 +194,7 @@ $ volta list --human
     Node: v8.16.0 (default)
     Yarn: v1.12.3 (default)
     Tool binaries available:
-        create-react-app, ember, tsc, tsserver, yarn-deduplicate
+        create-react-app, ember, tsc, tsserver
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -197,7 +208,7 @@ $ volta list --human
     Node: v8.16.0 (default)
     Yarn: v1.12.3 (default)
     Tool binaries available:
-        create-react-app, ember, tsc, tsserver, yarn-deduplicate
+        create-react-app, ember, tsc, tsserver
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -215,7 +226,7 @@ $ volta list --human
     Node: v8.16.0 (current @ ~/node-only/package.json)
     Yarn: v1.12.3 (default)
     Tool binaries available:
-        create-react-app, ember, tsc, tsserver, yarn-deduplicate
+        create-react-app, ember, tsc, tsserver
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -231,7 +242,7 @@ $ volta list --human
     Node runtime: v12.2.0 (current @ ~/node-and-yarn/package.json)
     Packager: Yarn: v1.16.0 (current @ ~/node-and-yarn/package.json)
     Tool binaries available:
-        create-react-app, ember, tsc, tsserver, yarn-deduplicate
+        create-react-app, ember, tsc, tsserver
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -353,7 +364,7 @@ $ volta list --all --human
                     runtime: node@v12.2.0
                     packager: built-in npm
         yarn-deduplicate:
-            v1.1.1 (default)
+            v1.1.1
                 binaries: yarn-deduplicate
                 platform:
                     runtime: node@v12.2.0
@@ -409,7 +420,7 @@ $ volta list --all --human
                     runtime: node@v12.2.0
                     packager: built-in npm
         yarn-deduplicate:
-            v1.1.1 (default)
+            v1.1.1
                 binaries: yarn-deduplicate
                 platform:
                     runtime: node@v12.2.0
@@ -465,7 +476,7 @@ $ volta list --all --human
                     runtime: node@v12.2.0
                     packager: built-in npm
         yarn-deduplicate:
-            v1.1.1 (default)
+            v1.1.1
                 binaries: yarn-deduplicate
                 platform:
                     runtime: node@v12.2.0
@@ -502,7 +513,7 @@ tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (default)
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 ```
 
 </details>
@@ -524,7 +535,7 @@ tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (default)
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 ```
 
 </details>
@@ -546,7 +557,7 @@ tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (default)
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 ```
 
 </details>

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -441,54 +441,20 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (defau
 
 ```sh
 $ volta list --all
-⚡️ User toolchain:
-
-    Node runtimes:
-        v12.2.0
-        v11.9.0
-        v10.15.3 (default)
-        v8.16.0 (current)
-    
-    Packagers:
-        Yarn:
-            v1.16.0 (default)
-            v1.12.3
-    
-    Tools:
-        create-react-app:
-            v3.0.1 (default)
-                binaries: create-react-app
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-        ember-cli:
-            v3.10.0 (default)
-                binaries: ember
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-            v3.8.2
-                binaries: ember
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-        tsc:
-            v3.4.5
-                binaries: tsc, tsserver
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-            v3.0.3 (default)
-                binaries: tsc, tsserver
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
-        yarn-deduplicate:
-            v1.1.1 (default)
-                binaries: yarn-deduplicate
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
+runtime node@v12.2.0
+runtime node@v11.9.0
+runtime node@v10.15.3 (default)
+runtime node@v8.16.0 (current@~/node-only/package.json)
+packager yarn@v1.16.0 (default)
+packager yarn@v1.12.3
+tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
+tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
+tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
+tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
+tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
+tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
+tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (default)
 ```
 
 </details>

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -16,12 +16,12 @@ Add an informational command, `volta list`, replacing the `volta current` comman
 - [Details](#details)
     - [Information supplied by the command](#information-supplied-by-the-command)
     - [Output modes](#output-modes)
-    - [Detailed Command Output](#detailed-command-output)
+    - [Detailed command output](#detailed-command-output)
         - [Assumed Configuration](#assumed-configuration)
         - [`volta list` (no flags)](#volta-list-no-flags)
         - [`volta list all`](#volta-list-all)
-        - [`volta list package <package>`](#volta-list-package-package)
-        - [`volta list tool <tool>`](#volta-list-tool-tool)
+        - [`volta list <package>`](#volta-list-package)
+        - [`volta list <tool>`](#volta-list-tool)
     - [Deprecating `volta current`](#deprecating-volta-current)
 - [Critique](#critique)
     - [Use another command name](#use-another-command-name)
@@ -600,7 +600,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 
 </details>
 
-### `volta list package <package>`
+### `volta list <package>`
 
 List all fetched versions of a specific package, along with its associated binaries.
 
@@ -609,7 +609,7 @@ List all fetched versions of a specific package, along with its associated binar
 The basic format is:
 
 ```sh
-volta list package <package> --human
+volta list <package> --human
 
     <version> [(default|current @ <project path>)]
         binaries: [<binary name>]...
@@ -641,28 +641,28 @@ volta list package typescript --human
 The basic format is:
 
 ```sh
-volta list package <package> --plain
+volta list <package> --plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list package typescript --plain
+volta list typescript --plain
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 ```
 
-### `volta list tool <tool>`
+### `volta list <tool>`
 
 #### Human
 
 The basic format is:
 
 ```sh
-volta list tool <tool> --human
+volta list <tool> --human
 ⚡️ tool <tool> available from:
 
     <package>@<version> [(default|current @ <project path>)]
@@ -674,7 +674,7 @@ volta list tool <tool> --human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list tool tsc --human
+volta list tsc --human
 ⚡️ tool tsc available from:
 
     typescript@v3.4.5
@@ -693,14 +693,14 @@ volta list tool tsc --human
 The basic format is:
 
 ```sh
-volta list tool <tool> --plain
+volta list <tool> --plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list tool tsc
+volta list tsc
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 ```
@@ -722,8 +722,8 @@ If another option is preferred, e.g. `toolchain`, `list` could be a (hidden) ali
 
 One alternative direction suggested by nodenv's approach is to supply shorthands:
 
-- `volta list package <package>` → `volta package <package>`
-- `volta list tool <tool>` → `volta tool <tool>`
+- `volta list <package>` → `volta package <package>`
+- `volta list <tool>` → `volta tool <tool>`
 
 However, in nodenv's case, those subcommands are also used for installation, which we are *not* doing under the current design of `install`. Moreover, the distinction drawn above is *not* presented in our installation process. That is, we do not actually allow users to install *tools* by name today, only *packages*. (This may suggest a simplification is in order; see [Unresolved Questions][unresolved] below.)
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -20,8 +20,6 @@ Add an informational command, `volta list`, replacing the `volta current` comman
         - [Assumed Configuration](#assumed-configuration)
         - [`volta list` (no flags)](#volta-list-no-flags)
         - [`volta list all`](#volta-list-all)
-        - [`volta list node`](#volta-list-node)
-        - [`volta list <npm|yarn>`](#volta-list-npmyarn)
         - [`volta list <package>`](#volta-list-package)
         - [`volta list <tool>`](#volta-list-tool)
     - [Deprecating `volta current`](#deprecating-volta-current)

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -152,9 +152,9 @@ The `volta list` command always prints the following information for a set of ru
 
 The tool will support multiple modes (two initially), which include exactly the same information but presented in different human- or machine-friendly formats. All modes include the same information for runtimes, packagers, and tools: name, version, whether it is a default or project-specified version, and (for tools) the Node version and packager (i.e. platform).
 
-- "human" mode, the default if the context is a user-facing terminal; also invokable with `--print=human` in any context. An indented listing of the user's current runtime, packager (if specified), and any installed binaries. See the detailed sections below for examples of the format.
+- "human" mode, the default if the context is a user-facing terminal; also invokable with `--format=human` in any context. An indented listing of the user's current runtime, packager (if specified), and any installed binaries. See the detailed sections below for examples of the format.
 
-- "plain" mode, the default if the context is not a user-facing terminal (e.g. when piped into another command); also invokable with `--print=plain` in any context. A simple plain text format which prints a line per runtime, packager, or tool, with space-separated output on each line.
+- "plain" mode, the default if the context is not a user-facing terminal (e.g. when piped into another command); also invokable with `--format=plain` in any context. A simple plain text format which prints a line per runtime, packager, or tool, with space-separated output on each line.
 
     - runtimes:
 
@@ -174,7 +174,7 @@ The tool will support multiple modes (two initially), which include exactly the 
         tool <tool name> / <package name>@<package version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
         ```
 
-This RFC does not propose, but allows for the possibility of, a JSON mode (`--print=json`) or similar at a later time if that proves desirable.
+This RFC does not propose, but allows for the possibility of, a JSON mode (`--format=json`) or similar at a later time if that proves desirable.
 
 ## Detailed command output
 
@@ -226,7 +226,7 @@ They also have two projects with the following pins:
 The format is:
 
 ```sh
-$ volta list --print=human
+$ volta list --format=human
 ⚡️ Currently active tools:
 
     Node: <version> (default|current @ <project path>)
@@ -240,7 +240,7 @@ See options for more detailed reports by running `volta list --help`.
 <details><summary>Outside a project</summary>
 
 ```sh
-$ volta list --print=human
+$ volta list --format=human
 ⚡️ Currently active tools:
 
     Node: v8.16.0 (default)
@@ -258,7 +258,7 @@ See options for more detailed reports by running `volta list --help`.
 <b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
 
 ```sh
-$ volta list --print=human
+$ volta list --format=human
 ⚡️ Currently active tools:
 
     Node: v8.16.0 (current @ ~/node-only/package.json)
@@ -274,7 +274,7 @@ See options for more detailed reports by running `volta list --help`.
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list --print=human
+$ volta list --format=human
 ⚡️ Currently active tools:
 
     Node runtime: v12.2.0 (current @ ~/node-and-yarn/package.json)
@@ -292,7 +292,7 @@ See options for more detailed reports by running `volta list --help`.
 The format is:
 
 ```sh
-$ volta list --print=plain
+$ volta list --format=plain
 runtime node@<version> (default|current @ <project path>)
 packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 ```
@@ -300,7 +300,7 @@ packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 <details><summary>Outside a project</summary>
 
 ```sh
-$ volta list --print=plain
+$ volta list --format=plain
 runtime node@v10.15.3 (default)
 packager yarn@v1.12.3 (default)
 ```
@@ -312,7 +312,7 @@ packager yarn@v1.12.3 (default)
 <b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
 
 ```sh
-$ volta list --print=plain
+$ volta list --format=plain
 runtime node@v8.16.0 (~/node-only/package.json)
 packager yarn@v1.12.3 (default)
 ```
@@ -322,7 +322,7 @@ packager yarn@v1.12.3 (default)
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list --print=plain
+$ volta list --format=plain
 runtime node@v12.2.0 (~/node-and-yarn/package.json)
 packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 ```
@@ -336,7 +336,7 @@ packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 The basic format is:
 
 ```sh
-$ volta list all --print=human
+$ volta list all --format=human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -358,7 +358,7 @@ $ volta list all --print=human
 <details><summary>Outside a project directory</summary>
 
 ```sh
-$ volta list all --print=human
+$ volta list all --format=human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -411,7 +411,7 @@ $ volta list all --print=human
 <details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-$ volta list all --print=human
+$ volta list all --format=human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -464,7 +464,7 @@ $ volta list all --print=human
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list all --print=human
+$ volta list all --format=human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -519,7 +519,7 @@ $ volta list all --print=human
 The basic format is:
 
 ```sh
-$ volta list all --print=plain
+$ volta list all --format=plain
 runtime node@<version> [(default|current @ <project path>)]
 packager <packager>@<version> [(default|current @ <project path>)]
 tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
@@ -528,7 +528,7 @@ tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<versio
 <details><summary>Outside a project directory</summary>
 
 ```sh
-$ volta list all --print=plain
+$ volta list all --format=plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -550,7 +550,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1
 <details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-$ volta list all --print=plain
+$ volta list all --format=plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -572,7 +572,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list all --print=plain
+$ volta list all --format=plain
 runtime node@v12.2.0 (current @ ~/node-and-yarn/project.json)
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -600,7 +600,7 @@ List all fetched versions of a specific package, along with its associated binar
 The basic format is:
 
 ```sh
-volta list <package> --print=human
+volta list <package> --format=human
 
     <version> [(default|current @ <project path>)]
         binaries: [<binary name>]...
@@ -612,7 +612,7 @@ volta list <package> --print=human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list package typescript --print=human
+volta list package typescript --format=human
 
     v3.4.5
         binaries: tsc, tsserver
@@ -632,14 +632,14 @@ volta list package typescript --print=human
 The basic format is:
 
 ```sh
-volta list <package> --print=plain
+volta list <package> --format=plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list typescript --print=plain
+volta list typescript --format=plain
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
@@ -653,7 +653,7 @@ tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 The basic format is:
 
 ```sh
-volta list <tool> --print=human
+volta list <tool> --format=human
 ⚡️ tool <tool> available from:
 
     <package>@<version> [(default|current @ <project path>)]
@@ -665,7 +665,7 @@ volta list <tool> --print=human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list tsc --print=human
+volta list tsc --format=human
 ⚡️ tool tsc available from:
 
     typescript@v3.4.5
@@ -684,7 +684,7 @@ volta list tsc --print=human
 The basic format is:
 
 ```sh
-volta list <tool> --print=plain
+volta list <tool> --format=plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -687,16 +687,6 @@ tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 
 Since `volta list` subsumes (and substantially extends upon) the functionality of `volta current`, `volta current` should be deprecated when `volta list` is implemented. The deprecation should include a warning that the command will be removed in a future version and information about how to use `volta list --current <tool>` as a replacement.
 
-<!--
-This is the technical portion of the RFC. Explain the design in sufficient detail that:
-
-- Its interaction with other features is clear.
-- It is reasonably clear how the feature would be implemented.
-- Corner cases are dissected by example.
-
-This section should return to the examples given in the previous section, and explain more fully how the detailed proposal makes those examples work.
--->
-
 # Critique
 [critique]: #critique
 
@@ -766,8 +756,3 @@ We could leave the current state of affairs as it is. However, users then have n
     - associated with the runtime it ships with, e.g. `v12.2.0 (with npm v6.4.1)`
     - as a packager, but indicating its source as a built-in, e.g. `npm v6.4.1 (built-in from node@v12.2.0`
 
-<!-- 
-- What parts of the design do you expect to resolve through the RFC process before this gets merged?
-- What parts of the design do you expect to resolve through the implementation of this feature before stabilization?
-- What related issues do you consider out of scope for this RFC that could be addressed in the future independently of the solution that comes out of this RFC?
--->

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -137,7 +137,7 @@ The `volta list` command supports four *variants*:
 
 - **`volta list <tool>`:** shows a subset of the output from `all`, scoped to the information for a specific tool which has been fetched to the user’s inventory. `tool` is similar to `package`, but if a package has more than one tool associated with it, only the specified tool will be shown.
 
-The command also supports (initially) two *output modes*: *human-friendly* (`human`) and *machine-friendly* (`plain`).
+The command also supports (initially) two *output modes*: *human-friendly* (`human`) and *machine-friendly* (`plain`). It may later be expanded to support JSON or other machine-focused outputs.
 
 ## Information supplied by the command
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -676,6 +676,8 @@ This section discusses the tradeoffs considered in this proposal. This must incl
 
     And how should that be presented in `plain` vs. `human` mode? Should there be any differences between `plain` and `human` for the bare command (as in the current design)?
 
+- How should the current version be identified? It is currently marked with `(current @ <path>)`. Should this be `(from <path>)` or some other design?
+
 <!-- 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?
 - What parts of the design do you expect to resolve through the implementation of this feature before stabilization?

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -228,7 +228,7 @@ $ volta list --all
             <version> [(default|current @ <project path>)]
     
     Tools:
-        <tool name>
+        <package name>
             <version> [(default|current @ <project path>)]
                 binaries: [<binary name>]...
                 platform:

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -93,7 +93,7 @@ The tool will support multiple modes (two initially), which include exactly the 
     - tools: 
 
         ```
-        tool <tool name>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
+        tool <tool name> / <package name>@<package version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
         ```
 
 This RFC does not propose, but allows for the possibility of, a JSON mode (`--print=json`) or similar at a later time if that proves desirable.

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -226,7 +226,7 @@ They also have two projects with the following pins:
 The format is:
 
 ```sh
-$ volta list --human
+$ volta list --print=human
 ⚡️ Currently active tools:
 
     Node: <version> (default|current @ <project path>)
@@ -240,7 +240,7 @@ See options for more detailed reports by running `volta list --help`.
 <details><summary>Outside a project</summary>
 
 ```sh
-$ volta list --human
+$ volta list --print=human
 ⚡️ Currently active tools:
 
     Node: v8.16.0 (default)
@@ -258,7 +258,7 @@ See options for more detailed reports by running `volta list --help`.
 <b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
 
 ```sh
-$ volta list --human
+$ volta list --print=human
 ⚡️ Currently active tools:
 
     Node: v8.16.0 (current @ ~/node-only/package.json)
@@ -274,7 +274,7 @@ See options for more detailed reports by running `volta list --help`.
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list --human
+$ volta list --print=human
 ⚡️ Currently active tools:
 
     Node runtime: v12.2.0 (current @ ~/node-and-yarn/package.json)
@@ -292,7 +292,7 @@ See options for more detailed reports by running `volta list --help`.
 The format is:
 
 ```sh
-$ volta list --plain
+$ volta list --print=plain
 runtime node@<version> (default|current @ <project path>)
 packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 ```
@@ -300,7 +300,7 @@ packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 <details><summary>Outside a project</summary>
 
 ```sh
-$ volta list --plain
+$ volta list --print=plain
 runtime node@v10.15.3 (default)
 packager yarn@v1.12.3 (default)
 ```
@@ -312,7 +312,7 @@ packager yarn@v1.12.3 (default)
 <b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
 
 ```sh
-$ volta list --plain
+$ volta list --print=plain
 runtime node@v8.16.0 (~/node-only/package.json)
 packager yarn@v1.12.3 (default)
 ```
@@ -322,7 +322,7 @@ packager yarn@v1.12.3 (default)
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list --plain
+$ volta list --print=plain
 runtime node@v12.2.0 (~/node-and-yarn/package.json)
 packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 ```
@@ -336,7 +336,7 @@ packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 The basic format is:
 
 ```sh
-$ volta list all --human
+$ volta list all --print=human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -358,7 +358,7 @@ $ volta list all --human
 <details><summary>Outside a project directory</summary>
 
 ```sh
-$ volta list all --human
+$ volta list all --print=human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -414,7 +414,7 @@ $ volta list all --human
 <details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-$ volta list all --human
+$ volta list all --print=human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -470,7 +470,7 @@ $ volta list all --human
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list all --human
+$ volta list all --print=human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -528,7 +528,7 @@ $ volta list all --human
 The basic format is:
 
 ```sh
-$ volta list all --plain
+$ volta list all --print=plain
 runtime node@<version> [(default|current @ <project path>)]
 packager <packager>@<version> [(default|current @ <project path>)]
 tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
@@ -537,7 +537,7 @@ tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<versio
 <details><summary>Outside a project directory</summary>
 
 ```sh
-$ volta list all --plain
+$ volta list all --print=plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -559,7 +559,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 <details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-$ volta list all --plain
+$ volta list all --print=plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -581,7 +581,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list all --plain
+$ volta list all --print=plain
 runtime node@v12.2.0 (current @ ~/node-and-yarn/project.json)
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -609,7 +609,7 @@ List all fetched versions of a specific package, along with its associated binar
 The basic format is:
 
 ```sh
-volta list <package> --human
+volta list <package> --print=human
 
     <version> [(default|current @ <project path>)]
         binaries: [<binary name>]...
@@ -621,7 +621,7 @@ volta list <package> --human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list package typescript --human
+volta list package typescript --print=human
 
     v3.4.5
         binaries: tsc, tsserver
@@ -641,14 +641,14 @@ volta list package typescript --human
 The basic format is:
 
 ```sh
-volta list <package> --plain
+volta list <package> --print=plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list typescript --plain
+volta list typescript --print=plain
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
@@ -662,7 +662,7 @@ tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 The basic format is:
 
 ```sh
-volta list <tool> --human
+volta list <tool> --print=human
 ⚡️ tool <tool> available from:
 
     <package>@<version> [(default|current @ <project path>)]
@@ -674,7 +674,7 @@ volta list <tool> --human
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list tsc --human
+volta list tsc --print=human
 ⚡️ tool tsc available from:
 
     typescript@v3.4.5
@@ -693,7 +693,7 @@ volta list tsc --human
 The basic format is:
 
 ```sh
-volta list <tool> --plain
+volta list <tool> --print=plain
 tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
 ```
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -536,6 +536,26 @@ tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 ```
 
+### `volta list --tool=<tool>`
+
+#### Human
+
+#### Plain
+
+The basic format is:
+
+```sh
+volta list --tool=<tool> --plain
+tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
+```
+
+For the TypeScript config specified in the canonical example:
+
+```sh
+volta list --tool=tsc
+tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
+tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
+```
 
 ## Why `list`?
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -483,7 +483,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (defau
 
 ### `volta list --package=<package>`
 
-List all fetched versions of a specific package.
+List all fetched versions of a specific package, along with its associated binaries.
 
 #### Human
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -354,6 +354,28 @@ Tools:
 
 </details>
 
+#### Plain
+
+<details><summary></summary>
+
+```sh
+$ volta list --all
+runtime node@v12.2.0
+runtime node@v11.9.0
+runtime node@v10.15.3 (default)
+runtime node@v8.16.0
+packager yarn@v1.16.0
+packager yarn@v1.12.3 (default)
+tool create-react-app@v3.0.1 (default) / node@v12.2.0
+tool ember-cli@v3.10.0 (default) / node@v12.2.0
+tool ember-cli@v3.8.2 / node@v12.2.0
+tool typescript@v3.4.5 / node@v12.2.0
+tool typescript@v3.0.3 (default) / node@v12.2.0
+tool yarn-deduplicate@v1.1.1 / node@v12.2.0
+```
+
+</details>
+
 ### `volta list <package>`
 
 List all fetched versions of a specific package:
@@ -362,10 +384,7 @@ List all fetched versions of a specific package:
 volta list <package>
 ```
 
-
-
-
-
+<!-- TODO: remaining examples! -->
 
 ## Why `list`?
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -229,10 +229,10 @@ The format is:
 $ volta list --human
 ⚡️ Currently active tools:
 
-    Node: v8.16.0 (default)
-    Yarn: v1.12.3 (default)
-    Tool binaries available:
-        create-react-app, ember, tsc, tsserver
+    Node: <version> (default|current @ <project path>)
+    <Yarn|npm>: v1.12.3 (default|current @ <project path>)
+    Tool binaries available: [NONE]
+        [<[<tool name>]>,]...
 
 See options for more detailed reports by running `volta list --help`.
 ```

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -168,6 +168,48 @@ See options for more detailed reports by running `volta list --help`.
     
 </details>
 
+#### Plain
+
+The format is:
+
+```sh
+$ volta list
+runtime node@<version> (default|<project path>)
+packager <npm|yarn>@<version> (built-in|default|<project path>)
+```
+
+<details><summary>Outside a project</summary>
+
+```sh
+$ volta list
+runtime node@v10.15.3 (default)
+packager yarn@v1.12.3 (default)
+```
+
+</details>
+
+<details><summary>In the `node-only` project</summary>
+
+<b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
+
+```sh
+$ volta list
+runtime node@v8.16.0 (`~/node-only/package.json`)
+packager yarn@v1.12.3 (default)
+```
+
+</details>
+
+<details><summary>In the <code>node-and-yarn</code> project</summary>
+
+```sh
+$ volta list
+node@v12.2.0 (`~/node-and-yarn/package.json`)
+yarn@v1.16.0 (`~/node-and-yarn/package.json`)
+```
+    
+</details>
+    
 ### `volta list --all`
 
 #### Human

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -63,7 +63,42 @@ They also have two projects with the following pins:
     }
     ```
 
-## CLI Command
+## CLI Command Design
+
+The `volta list` command always prints the following information for a set of runtimes, packagers, and tools:
+
+- name
+- version
+- whether it is the user's default or a project-pinned version
+- for tools, the associated runtime and packager versions
+
+The tool will support two modes initially: "human" and "plain", which include exactly the same information but presented in a  Both modes include the same information for runtimes, packagers, and tools: name, version, whether it is a default or project-specified version, and (for tools) the Node version and packager (i.e. platform).
+
+- "human" mode, the default if the context is a user-facing terminal; also invokable with `--print=human` in any context.
+
+- "plain" mode, the default if the context is not a user-facing terminal (e.g. when piped into another command); also invokable with `--print=plain` in any context. A simple plain text format which prints a line per runtime, packager, or tool, with space-separated output on each line.
+
+    - runtimes:
+
+        ```
+        runtime node@<version>
+        ```
+
+    - packagers:
+
+        ```
+        packager (yarn|npm)@<version>
+        ```
+
+    - tools: 
+
+        ```
+        tool <tool name>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|<project path>)]
+        ```
+
+Having these two modes should make it easy to add a JSON mode later (`--print=json`) if that proves desirable.
+
+## CLI Command Variants
 
 ### `volta list` (no flags)
 
@@ -328,55 +363,9 @@ volta list <package>
 ```
 
 
-### Plain mode design
 
-Running `volta list` in the non-TTY/line mode will print a space delimited set of data which can then be piped into other CLI tools which expect strings. The format is a list with tools sorted by name, and versions by semantic version.
 
-- Runtimes:
 
-    ```
-    runtime node@<version>
-    ```
-
-- Packagers:
-
-    ```
-    packager (yarn|npm)@<version>
-    ```
-
-- Tools: 
-
-    ```
-    tool <tool name>@<tool version>[ (default)] [/ node@<version>] [/ (yarn|npm)@<version>]
-    ```
-
-For our canonical example, the outputs from `--print=plain` would be:
-
-- bare subcommand:
-
-    ```sh
-    $ volta list --print=plain
-    runtime node@v10.15.3 (default)
-    packager yarn@v1.12.3 (default)
-    ```
-
-- `--all`:
-
-    ```sh
-    $ volta list --all --print=plain
-    runtime node@v12.2.0
-    runtime node@v11.9.0
-    runtime node@v10.15.3 (default)
-    runtime node@v8.16.0
-    packager yarn@v1.16.0
-    packager yarn@v1.12.3 (default)
-    tool create-react-app@v3.0.1 (default) / node@v12.2.0
-    tool ember-cli@v3.10.0 (default) / node@v12.2.0
-    tool ember-cli@v3.8.2 / node@v12.2.0
-    tool typescript@v3.4.5 / node@v12.2.0
-    tool typescript@v3.0.3 (default) / node@v12.2.0
-    tool yarn-deduplicate@v1.1.1 / node@v12.2.0
-    ```
 
 ## Why `list`?
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -240,12 +240,12 @@ The format is:
 
 ```sh
 $ volta list --format=human
-⚡️ Currently active tools:
+Currently active tools:
 
     Node: <version> (default|current @ <project path>)
     <Yarn|npm>: v1.12.3 (default|current @ <project path>)
-    Tool binaries available: [NONE]
-        [<[<tool name>]>,]...
+    Package binaries available: [NONE]
+        [<tool name>,...]
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -254,11 +254,11 @@ See options for more detailed reports by running `volta list --help`.
 
 ```sh
 $ volta list --format=human
-⚡️ Currently active tools:
+Currently active tools:
 
     Node: v8.16.0 (default)
     Yarn: v1.12.3 (default)
-    Tool binaries available:
+    Package binaries available:
         create-react-app, ember, tsc, tsserver
 
 See options for more detailed reports by running `volta list --help`.
@@ -272,11 +272,11 @@ See options for more detailed reports by running `volta list --help`.
 
 ```sh
 $ volta list --format=human
-⚡️ Currently active tools:
+Currently active tools:
 
     Node: v8.16.0 (current @ ~/node-only/package.json)
     Yarn: v1.12.3 (default)
-    Tool binaries available:
+    Package binaries available:
         create-react-app, ember, tsc, tsserver
 
 See options for more detailed reports by running `volta list --help`.
@@ -288,11 +288,11 @@ See options for more detailed reports by running `volta list --help`.
 
 ```sh
 $ volta list --format=human
-⚡️ Currently active tools:
+Currently active tools:
 
     Node runtime: v12.2.0 (current @ ~/node-and-yarn/package.json)
     Package manager: Yarn: v1.16.0 (current @ ~/node-and-yarn/package.json)
-    Tool binaries available:
+    Package binaries available:
         create-react-app, ember, tsc, tsserver
 
 See options for more detailed reports by running `volta list --help`.
@@ -350,73 +350,72 @@ The basic format is:
 
 ```sh
 $ volta list all --format=human
-⚡️ User toolchain:
+User toolchain:
 
     Node runtimes:
-        <version> [(default|current @ <project path>)]
+        [default: <version>]
+        [current: <version> (@ <project path>)]
+        [fetched: <version>[, <version>...]]
 
     Package managers:
         (Yarn|npm):
-            <version> [(default|current @ <project path>)]
+            [default: <version>]
+            [current: <version> (@ <project path>)]
+            [fetched: <version>[, <version>...]]
 
-    Tools:
+    Packages:
         <package name>
-            <version> [(default|current @ <project path>)]
+            [current: <version> @ <project path>
                 binaries: [<binary name>]...
                 platform:
                     runtime: node@<version>
-                    package manager: built-in npm|<npm|yarn>@<version>
+                    package manager: built-in npm|<npm|yarn>@<version>]
+            [default: <version>
+                binaries: [<binary name>]...
+                platform:
+                    runtime: node@<version>
+                    package manager: built-in npm|<npm|yarn>@<version>]
+            [fetched: <version>[, <version>...]]
 ```
 
 <details><summary>Outside a project directory</summary>
 
 ```sh
 $ volta list all --format=human
-⚡️ User toolchain:
+User toolchain:
 
     Node runtimes:
-        v12.2.0
-        v11.9.0
-        v10.15.3 (default)
-        v8.16.0
+        default: v10.15.3
+        fetched: v8.16.0, v11.9.0, v12.2.0
 
     Package managers:
         Yarn:
-            v1.16.0 (default)
-            v1.12.3
+            default: v1.16.0
+            fetched: v1.12.3
 
-    Tools:
+    Packages:
         create-react-app:
-            v3.0.1 (default)
+            default: v3.0.1
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
         ember-cli:
-            v3.10.0 (default)
+            default: v3.10.0
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            v3.8.2
-                binaries: ember
-                platform:
-                    runtime: node@v12.2.0
-                    package manager: built-in npm
+            fetched: v3.8.2
         typescript:
-            v3.4.5
+            default: v3.0.3
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            v3.0.3 (default)
-                binaries: tsc, tsserver
-                platform:
-                    runtime: node@v12.2.0
-                    package manager: built-in npm
+            fetched: v3.4.5
         yarn-deduplicate:
-            v1.1.1
-                binaries: yarn-deduplicate
+            fetched: v1.1.1
 ```
 
 </details>
@@ -425,51 +424,41 @@ $ volta list all --format=human
 
 ```sh
 $ volta list all --format=human
-⚡️ User toolchain:
+User toolchain:
 
     Node runtimes:
-        v12.2.0
-        v11.9.0
-        v10.15.3 (default)
-        v8.16.0 (current)
+        current: v8.16.0 (from ~/node-only/package.json)
+        default: v10.15.3
+        fetched: v11.9.0, v12.2.0
 
     Package managers:
         Yarn:
-            v1.16.0 (default)
-            v1.12.3
+            default: v1.16.0
+            fetched: v1.12.3
 
-    Tools:
+    Packages:
         create-react-app:
-            v3.0.1 (default)
+            default: v3.0.1
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
         ember-cli:
-            v3.10.0 (default)
+            default: v3.10.0
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            v3.8.2
-                binaries: ember
-                platform:
-                    runtime: node@v12.2.0
-                    package manager: built-in npm
+            fetched: v3.8.2
         tsc:
-            v3.4.5
+            default: v3.0.3
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            v3.0.3 (default)
-                binaries: tsc, tsserver
-                platform:
-                    runtime: node@v12.2.0
-                    package manager: built-in npm
+            fetched: v3.4.5
         yarn-deduplicate:
-            v1.1.1
-                binaries: yarn-deduplicate
+            fetched: v1.1.1
 ```
 
 </details>
@@ -478,51 +467,41 @@ $ volta list all --format=human
 
 ```sh
 $ volta list all --format=human
-⚡️ User toolchain:
+User toolchain:
 
     Node runtimes:
-        v12.2.0 (current @ ~/node-and-yarn/project.json)
-        v11.9.0
-        v10.15.3 (default)
-        v8.16.0
+        current: v12.2.0 (from ~/node-and-yarn/project.json)
+        default: v10.15.3
+        fetched: v8.16.0, v11.9.0
 
     Package managers:
         Yarn:
-            v1.16.0 (default)
-            v1.12.3 (current @ ~/node-and-yarn/project.json)
+            default: v1.16.0
+            current: v1.12.3 (from ~/node-and-yarn/project.json)
 
-    Tools:
+    Packages:
         create-react-app:
-            v3.0.1 (default)
+            default: v3.0.1
                 binaries: create-react-app
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
         ember-cli:
-            v3.10.0 (default)
+            default: v3.10.0
                 binaries: ember
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            v3.8.2
-                binaries: ember
-                platform:
-                    runtime: node@v12.2.0
-                    package manager: built-in npm
+            fetched: v3.8.2
         tsc:
-            v3.4.5
+            default: v3.0.3
                 binaries: tsc, tsserver
                 platform:
                     runtime: node@v12.2.0
                     package manager: built-in npm
-            v3.0.3 (default)
-                binaries: tsc, tsserver
-                platform:
-                    runtime: node@v12.2.0
-                    package manager: built-in npm
+            fetched: v3.4.5
         yarn-deduplicate:
-            v1.1.1
-                binaries: yarn-deduplicate
+            fetched: v1.1.1
 ```
 
 </details>
@@ -535,7 +514,8 @@ The basic format is:
 $ volta list all --format=plain
 runtime node@<version> [(default|current @ <project path>)]
 package-manager <packager>@<version> [(default|current @ <project path>)]
-tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
+package <package>@<version> / [<tool>, ...] / <npm|yarn>@<built-in|version> (default|current @ <path>)
+package <name>@<version> (fetched)
 ```
 
 <details><summary>Outside a project directory</summary>
@@ -548,14 +528,12 @@ runtime node@v10.15.3 (default)
 runtime node@v8.16.0
 package-manager yarn@v1.16.0 (default)
 package-manager yarn@v1.12.3
-tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
-tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
-tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
-tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
-tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
-tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1
+package create-react-app@v3.0.1 / create-react-app / node@v12.2.0 npm@built-in (default)
+package ember-cli@v3.10.0 / ember / node@v12.2.0 npm@built-in (default)
+package ember-cli@v3.8.2 (fetched)
+package typescript@v3.4.5 (fetched)
+package typescript@v3.0.3 / tsc, tsserver / node@v12.2.0 npm@built-in (default)
+package yarn-deduplicate@v1.1.1 (fetched)
 ```
 
 </details>
@@ -570,14 +548,12 @@ runtime node@v10.15.3 (default)
 runtime node@v8.16.0 (current @ ~/node-only/package.json)
 package-manager yarn@v1.16.0 (default)
 package-manager yarn@v1.12.3
-tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
-tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
-tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
-tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
-tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
-tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1
+package create-react-app@v3.0.1 / create-react-app / node@v12.2.0 npm@built-in (default)
+package ember-cli@v3.10.0 / ember / node@v12.2.0 npm@built-in (default)
+package ember-cli@v3.8.2 (fetched)
+package typescript@v3.4.5 (fetched)
+package typescript@v3.0.3 / tsc, tsserver / node@v12.2.0 npm@built-in (default)
+package yarn-deduplicate@v1.1.1 (fetched)
 ```
 
 </details>
@@ -592,14 +568,12 @@ runtime node@v10.15.3 (default)
 runtime node@v8.16.0
 package-manager yarn@v1.16.0 (default)
 package-manager yarn@v1.12.3 (current @ ~/node-and-yarn/project.json)
-tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
-tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
-tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
-tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
-tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
-tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1
+package create-react-app@v3.0.1 / create-react-app / node@v12.2.0 npm@built-in (default)
+package ember-cli@v3.10.0 / ember / node@v12.2.0 npm@built-in (default)
+package ember-cli@v3.8.2 (fetched)
+package typescript@v3.4.5 (fetched)
+package typescript@v3.0.3 / tsc, tsserver / node@v12.2.0 npm@built-in (default)
+package yarn-deduplicate@v1.1.1 (fetched)
 ```
 
 </details>
@@ -615,29 +589,27 @@ The basic format is:
 ```sh
 volta list <package> --format=human
 
-    <version> [(default|current @ <project path>)]
+    [default: <version>|current: <version>(from @ <project path>)
         binaries: [<binary name>]...
         platform:
             runtime: node@<version>
-            package manager: built-in npm|<npm|yarn>@<version>
+            package manager: built-in npm|<npm|yarn>@<version>]
+    [fetched: [<version>, ...]]
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list package typescript --format=human
+volta list typescript --format=human
+<package> versions in toolchain:
 
-    v3.4.5
+    default: v3.0.3
         binaries: tsc, tsserver
         platform:
             runtime: node@v12.2.0
             package manager: built-in npm
 
-    v3.0.3 (default)
-        binaries: tsc, tsserver
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
+    fetched: v3.4.5
 ```
 
 #### Plain
@@ -646,17 +618,16 @@ The basic format is:
 
 ```sh
 volta list <package> --format=plain
-tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
+package <package>@<version> / [<tool>, ...] / <npm|yarn>@<built-in|version> (default|current @ <path>)
+package <package>@<version> (fetched)
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
 volta list typescript --format=plain
-tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
-tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
-tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
-tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
+package typescript@v3.0.3 / tsc, tsserver / node@12.2.0 npm@built-in (default)
+package typescript@v3.4.5 (fetched)
 ```
 
 ### `volta list <tool>`
@@ -667,9 +638,9 @@ The basic format is:
 
 ```sh
 volta list <tool> --format=human
-⚡️ tool <tool> available from:
+tool <tool> available from package:
 
-    <package>@<version> [(default|current @ <project path>)]
+    [default: <package>@<version>|current <package>@<version> (@ <project path>)]
         platform:
             runtime: node@<version>
             package manager: built-in npm|<npm|yarn>@<version>
@@ -679,14 +650,9 @@ For the TypeScript config specified in the canonical example:
 
 ```sh
 volta list tsc --format=human
-⚡️ tool tsc available from:
+tool tsc available from:
 
-    typescript@v3.4.5
-        platform:
-            runtime: node@v12.2.0
-            package manager: built-in npm
-
-    typescript@v3.0.3 (default)
+    default: typescript@v3.0.3
         platform:
             runtime: node@v12.2.0
             package manager: built-in npm
@@ -694,19 +660,18 @@ volta list tsc --format=human
 
 #### Plain
 
-The basic format is:
+The basic format is the same as the format for packages, but `fetched` can never appear (under the current implementation limitations):
 
 ```sh
 volta list <tool> --format=plain
-tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
+package <package>@<version> / [<tool>, ...] / <npm|yarn>@<built-in|version> (default|current @ <path>)
 ```
 
 For the TypeScript config specified in the canonical example:
 
 ```sh
 volta list tsc
-tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
-tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
+package typescript@v3.0.3 / tsc, tsserver / node@12.2.0 npm@built-in (default)
 ```
 
 ## Deprecating `volta current`
@@ -735,12 +700,12 @@ Additionally, we might consider here (and people have suggested in discussions i
 
 ```sh
 $ volta
-⚡️ Volta 0.5.2
+Volta 0.5.2
 Currently active tools:
 
     Node: v8.16.0 (default)
     Yarn: v1.12.3 (from ~/node-and-yarn/package.json)
-    Tool binaries available:
+    Package binaries available:
         create-react-app, ember, tsc, tsserver
 
 To install a tool in your toolchain, use `volta install`.

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -26,16 +26,21 @@ Adding a `volta list` command designed to address all of these needs allows user
 # Pedagogy
 [pedagogy]: #pedagogy
 
-<!--
-How should we explain and teach this feature to users? How should users understand this feature? This generally means:
+We introduce a `list` command, which lets users get a description of their Volta environment: the currently-active items in their toolchain and the reason those items are currently active, and the total set of available tools on their system.
 
-- Introducing new named concepts.
-- Explaining the feature largely in terms of examples.
-- Explaining how users should _think_ about the feature, and how it should impact the way they use Volta. It should explain the impact as concretely as possible.
-- If applicable, describe the differences between teaching this to existing Node programmers and new Node programmers.
+- To get the currently-active runtime, packager, and available binaries, the user can run `volta list`.
 
-It is not necessary to write the actual feature documentation in this section, but it should establish the concepts on which the documentation would be built.
--->
+- To get *all* runtimes, packagers, and binaries currently fetched to the user's system, the user can run `volta list --all`.
+
+- The user can also narrow the query:
+    - to runtimes: `volta list node`
+    - to packagers: `volta list npm` or `volta list yarn`
+    - to a specific package: `volta list package <package name>`
+    - to a specific tool: `volta list tool <tool name>`
+
+These commands represent the Volta ideas of the user's *toolchain*, including *default* and *current* items within that chain.
+
+These ideas already exist implicitly in Volta's vocabulary. Introducing `list` provides a specific place for users to see what the terms mean and how they are employed. Indeed, one of the primary benefits of the `list` command is that it provides a point where the Volta model—as distinct from e.g. the nvm or nodenv models—can be *made explicit* and thereby taught to users.
 
 ## Why `list`?
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -133,6 +133,32 @@ See options for more detailed reports by running `volta list --help`.
     
 </details>
 
+### `volta list --all`
+
+#### Pretty
+
+The basic format is:
+
+```sh
+$ volta list --all
+Node runtimes:
+    <version> [(default|project)]
+
+Packagers:
+    (Yarn|npm):
+        <version> [(default|project)]
+
+Tools:
+    <tool name>
+        <version> [(default|project)]
+            binaries: [<binary name>]...
+            platform:
+                runtime: node@<version>
+                packager: built-in npm|<npm|yarn>@<version>
+```
+
+<details><summary>Outside a project directory</summary>
+
 ```sh
 $ volta list --all
 Node runtimes:
@@ -183,12 +209,117 @@ Tools:
                 packager: built-in npm
 ```
 
-Filter the list of fetched tools to a specific context: tools set as a user default, or tools set for a project toolchain.
+</details>
+
+<details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-volta list --default
-volta list --project
+$ volta list --all
+Node runtimes:
+    v12.2.0
+    v11.9.0
+    v10.15.3 (default)
+    v8.16.0 (current)
+
+Packagers:
+    Yarn:
+        v1.16.0 (default)
+        v1.12.3
+
+Tools:
+    create-react-app:
+        v3.0.1 (default)
+            binaries: create-react-app
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+    ember-cli:
+        v3.10.0 (default)
+            binaries: ember
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+        v3.8.2
+            binaries: ember
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+    tsc:
+        v3.4.5
+            binaries: tsc, tsserver
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+        v3.0.3 (default)
+            binaries: tsc, tsserver
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+    yarn-deduplicate:
+        v1.1.1 (default)
+            binaries: yarn-deduplicate
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
 ```
+
+</details>
+
+<details><summary>In the <code>node-and-yarn</code> project</summary>
+
+```sh
+$ volta list --all
+Node runtimes:
+    v12.2.0 (project)
+    v11.9.0
+    v10.15.3 (default)
+    v8.16.0
+
+Packagers:
+    Yarn:
+        v1.16.0 (default)
+        v1.12.3 (project)
+
+Tools:
+    create-react-app:
+        v3.0.1 (default)
+            binaries: create-react-app
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+    ember-cli:
+        v3.10.0 (default)
+            binaries: ember
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+        v3.8.2
+            binaries: ember
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+    tsc:
+        v3.4.5
+            binaries: tsc, tsserver
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+        v3.0.3 (default)
+            binaries: tsc, tsserver
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+    yarn-deduplicate:
+        v1.1.1 (default)
+            binaries: yarn-deduplicate
+            platform:
+                runtime: node@v12.2.0
+                packager: built-in npm
+```
+
+</details>
+
+### `volta list <package>`
 
 List all fetched versions of a specific package:
 
@@ -196,19 +327,6 @@ List all fetched versions of a specific package:
 volta list <package>
 ```
 
-## Command modes
-
-The `volta list` command should work in two modes initially. Both include the tool name, version, whether it is the default, and the Node version and packager (i.e. platform).
-
-- "pretty" mode, the default if the context is a user-facing terminal; also invokable with `--print=pretty` in any context. The format is a table of data, with a row per tool and a column for each field of interest.
-
-- "plain" mode, the default if the context is not a user-facing terminal (e.g. when piped into another command); also invokable with `--print=plain` in any context. A simple plain text format which prints a single line with space separated output for each tool matching the query
-
-Having these two modes should make it easy to add a JSON mode later (`--print=json`) if that proves desirable.
-
-### Pretty mode design
-
-<!-- TODO -->
 
 ### Plain mode design
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -71,7 +71,7 @@ Top-level command: show the current to
 $ volta list
 ⚡️ Currently active toolchain:
 
-    Node: v8.16.0 (from `~/path/to/project/package.json`)
+    Node: v8.16.0 (from `~/pinned/node-only/package.json`)
     Yarn: v1.12.3 (default)
     Package binaries available:
         create-react-app, ember, tsc, tsserver, yarn-deduplicate

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -194,7 +194,7 @@ packager yarn@v1.12.3 (default)
 
 ```sh
 $ volta list
-runtime node@v8.16.0 (`~/node-only/package.json`)
+runtime node@v8.16.0 (~/node-only/package.json)
 packager yarn@v1.12.3 (default)
 ```
 
@@ -204,8 +204,8 @@ packager yarn@v1.12.3 (default)
 
 ```sh
 $ volta list
-runtime node@v12.2.0 (`~/node-and-yarn/package.json`)
-packager yarn@v1.16.0 (`~/node-and-yarn/package.json`)
+runtime node@v12.2.0 (~/node-and-yarn/package.json)
+packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 ```
     
 </details>
@@ -221,11 +221,11 @@ $ volta list --all
 ⚡️ User toolchain:
 
     Node runtimes:
-        <version> [(default|<project path>)]
+        <version> [(default|current @ <project path>)]
     
     Packagers:
         (Yarn|npm):
-            <version> [(default|<project path>)]
+            <version> [(default|current @ <project path>)]
     
     Tools:
         <tool name>
@@ -355,7 +355,7 @@ $ volta list --all
 ⚡️ User toolchain:
 
     Node runtimes:
-        v12.2.0 (`~/node-and-yarn/project.json`)
+        v12.2.0 (current @ ~/node-and-yarn/project.json)
         v11.9.0
         v10.15.3 (default)
         v8.16.0
@@ -363,7 +363,7 @@ $ volta list --all
     Packagers:
         Yarn:
             v1.16.0 (default)
-            v1.12.3 (`~/node-and-yarn/project.json`)
+            v1.12.3 (current @ ~/node-and-yarn/project.json)
     
     Tools:
         create-react-app:

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -145,12 +145,25 @@ The `volta list` command always prints the following information for a set of ru
 
 - name
 - version
-- whether it is the user's default or a project-pinned version
+- whether it is the user's default toolchain or a project version
 - for tools, the associated runtime and packager versions
 
-## Output modes
+## Flags
 
-The tool will support multiple modes (two initially), which include exactly the same information but presented in different human- or machine-friendly formats. All modes include the same information for runtimes, packagers, and tools: name, version, whether it is a default or project-specified version, and (for tools) the Node version and packager (i.e. platform).
+Besides the subcommands, `volta list` accepts *context* flags and *output mode* flags.
+
+### Context
+
+The tool supports limiting the output to either the *current* or the *default* values for any given argument:
+
+- `--current`: prints the *currently active* tool or set of tools (per the invoked command), along with their source
+- `--default`: prints the user's *default* tool or set of tools (per the invoked command)
+
+The two are *optional* and *mutually exclusive*.
+
+### Output modes
+
+The tool will support multiple modes (two initially), which include exactly the same information but presented in different human- or machine-friendly formats. All modes include the same information for runtimes, packagers, and tools: name, version, whether it is a user- or project-specified version, and (for tools) the Node version and packager (i.e. platform).
 
 - "human" mode, the default if the context is a user-facing terminal; also invokable with `--format=human` in any context. An indented listing of the user's current runtime, packager (if specified), and any installed binaries. See the detailed sections below for examples of the format.
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -540,6 +540,35 @@ tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 
 #### Human
 
+The basic format is:
+
+```sh
+volta list --tool=<tool> --human
+⚡️ tool tsc available from:
+
+    <package>@<version> [(default|current @ <project path>)]
+        platform:
+            runtime: node@<version>
+            packager: built-in npm|<npm|yarn>@<version>
+```
+
+For the TypeScript config specified in the canonical example:
+
+```sh
+volta list --tool=tsc --human
+⚡️ tool tsc available from:
+
+    typescript@v3.4.5
+        platform:
+            runtime: node@v12.2.0
+            packager: built-in npm
+
+    typescript@v3.0.3 (default)
+        platform:
+            runtime: node@v12.2.0
+            packager: built-in npm
+```
+
 #### Plain
 
 The basic format is:

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -42,7 +42,7 @@ Throughout, we will assume the user has the following configuration for illustra
 
 They also have two projects with the following pins:
 
-- `~/pinned/node-only/package.json`: f
+- `~/pinned/node-only/package.json`:
 
     ```json
     {

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -107,7 +107,7 @@ This RFC does not propose, but allows for the possibility of, a JSON mode (`--pr
 The format is:
 
 ```sh
-$ volta list
+$ volta list --human
 ⚡️ Currently active tools:
 
     Node: v8.16.0 (default)
@@ -121,7 +121,7 @@ See options for more detailed reports by running `volta list --help`.
 <details><summary>Outside a project</summary>
 
 ```sh
-$ volta list
+$ volta list --human
 ⚡️ Currently active tools:
 
     Node: v8.16.0 (default)
@@ -139,7 +139,7 @@ See options for more detailed reports by running `volta list --help`.
 <b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
 
 ```sh
-$ volta list
+$ volta list --human
 ⚡️ Currently active tools:
 
     Node: v8.16.0 (from `~/node-only/package.json`)
@@ -155,7 +155,7 @@ See options for more detailed reports by running `volta list --help`.
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list
+$ volta list --human
 ⚡️ Currently active tools:
 
     Node runtime: v12.2.0 (from `~/node-and-yarn/package.json`)
@@ -173,7 +173,7 @@ See options for more detailed reports by running `volta list --help`.
 The format is:
 
 ```sh
-$ volta list
+$ volta list --plain
 runtime node@<version> (default|current@ <project path>)
 packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 ```
@@ -181,7 +181,7 @@ packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 <details><summary>Outside a project</summary>
 
 ```sh
-$ volta list
+$ volta list --plain
 runtime node@v10.15.3 (default)
 packager yarn@v1.12.3 (default)
 ```
@@ -193,7 +193,7 @@ packager yarn@v1.12.3 (default)
 <b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
 
 ```sh
-$ volta list
+$ volta list --plain
 runtime node@v8.16.0 (~/node-only/package.json)
 packager yarn@v1.12.3 (default)
 ```
@@ -203,7 +203,7 @@ packager yarn@v1.12.3 (default)
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list
+$ volta list --plain
 runtime node@v12.2.0 (~/node-and-yarn/package.json)
 packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 ```
@@ -217,7 +217,7 @@ packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 The basic format is:
 
 ```sh
-$ volta list --all
+$ volta list --all --human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -239,7 +239,7 @@ $ volta list --all
 <details><summary>Outside a project directory</summary>
 
 ```sh
-$ volta list --all
+$ volta list --all --human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -295,7 +295,7 @@ $ volta list --all
 <details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-$ volta list --all
+$ volta list --all --human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -351,7 +351,7 @@ $ volta list --all
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list --all
+$ volta list --all --human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -409,7 +409,7 @@ $ volta list --all
 The basic format is:
 
 ```sh
-$ volta list --all
+$ volta list --all --plain
 runtime node@<version> [(default|current @ <project path>)]
 packager <packager>@<version> [(default|current @ <project path>)]
 tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
@@ -418,7 +418,7 @@ tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<versio
 <details><summary>Outside a project directory</summary>
 
 ```sh
-$ volta list --all
+$ volta list --all --plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -440,7 +440,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (defau
 <details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-$ volta list --all
+$ volta list --all --plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -462,7 +462,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (defau
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list --all
+$ volta list --all --plain
 runtime node@v12.2.0 (current@~/node-and-yarn/project.json)
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -529,7 +529,7 @@ tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [
 For the TypeScript config specified in the canonical example:
 
 ```sh
-volta list --package=typescript
+volta list --package=typescript --plain
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -20,6 +20,8 @@ Add an informational command, `volta list`, replacing the `volta current` comman
         - [Assumed Configuration](#assumed-configuration)
         - [`volta list` (no flags)](#volta-list-no-flags)
         - [`volta list all`](#volta-list-all)
+        - [`volta list node`](#volta-list-node)
+        - [`volta list <npm|yarn>`](#volta-list-npmyarn)
         - [`volta list <package>`](#volta-list-package)
         - [`volta list <tool>`](#volta-list-tool)
     - [Deprecating `volta current`](#deprecating-volta-current)
@@ -600,6 +602,222 @@ tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool yarn-deduplicate / yarn-deduplicate@v1.1.1
+```
+
+</details>
+
+### `volta list node`
+
+List all fetched Node runtimes.
+
+#### Human
+
+The basic format is:
+
+```sh
+$ volta list node --format=human
+⚡️ Node runtimes in your toolchain:
+
+    <version> [(default|current @ <project path>)]
+```
+
+If the user has no Node runtimes installed:
+
+```sh
+$ volta list node --format=human
+⚡️ No Node runtimes installed!
+
+You can install a runtime by running `volta install node`. See `volta help install` for
+details and more options.
+```
+
+<details><summary>Outside a project</summary>
+
+```sh
+$ volta list node --format=human
+⚡️ Node runtimes in your toolchain:
+
+    v12.2.0
+    v11.9.0
+    v10.15.3 (default)
+    v8.16.0
+```
+
+</details>
+
+<details><summary>In the `node-only` project</summary>
+
+```sh
+$ volta list node --format=human
+⚡️ Node runtimes in your toolchain:
+
+    v12.2.0
+    v11.9.0
+    v10.15.3 (default)
+    v8.16.0 (current @ ~/node-only/package.json)
+```
+
+</details>
+
+<details><summary>In the `node-and-yarn` project</summary>
+
+```sh
+$ volta list node --format=human
+⚡️ Node runtimes in your toolchain:
+
+    v12.2.0 (current @ ~/node-and-yarn/package.json)
+    v11.9.0
+    v10.15.3 (default)
+    v8.16.0
+```
+
+</details>
+
+#### Plain
+
+The basic format is:
+
+```sh
+$ volta list node --format=plain
+runtime node@<version> [(default|current @ <project path>)]
+```
+
+If the user has no Node runtimes installed, print nothing.
+
+<details><summary>Outside a project</summary>
+
+```sh
+$ volta list node --format=human
+runtime node@v12.2.0
+runtime node@v11.9.0
+runtime node@v10.15.3 (default)
+runtime node@v8.16.0
+```
+
+</details>
+
+<details><summary>In the `node-only` project</summary>
+
+```sh
+$ volta list node --format=human
+runtime node@v12.2.0
+runtime node@v11.9.0
+runtime node@v10.15.3 (default)
+runtime node@v8.16.0 (current @ ~/node-only/package.json)
+```
+
+</details>
+
+<details><summary>In the `node-and-yarn` project</summary>
+
+```sh
+$ volta list node --format=human
+runtime node@v12.2.0 (current @ ~/node-and-yarn/package.json)
+runtime node@v11.9.0
+runtime node@v10.15.3 (default)
+runtime node@v8.16.0
+```
+
+</details>
+
+### `volta list <npm|yarn>`
+
+List all fetched npm or Yarn versions. (Currently only Yarn is implemented.)
+
+#### Human
+
+The basic format is:
+
+```sh
+$ volta list <npm|yarn> --format=human
+⚡️ <npm|Yarn> versions in your toolchain:
+
+    <version> [(default|current @ <project path>)]
+```
+
+If the user has no packagers installed:
+
+```sh
+$ volta list <npm|yarn> --format=human
+⚡️ No <npm|Yarn> versions installed.
+
+You can install a Yarn version by running `volta install yarn`. See `volta help install` for
+details and more options.
+```
+
+<details><summary>Outside a project</summary>
+
+```sh
+$ volta list yarn --format=human
+⚡️ Yarn versions in your toolchain:
+
+    v1.16.0
+    v1.12.3 (default)
+```
+
+</details>
+
+<details><summary>In the `node-only` project</summary>
+
+```sh
+$ volta list yarn --format=human
+⚡️ Yarn versions in your toolchain:
+
+    v1.16.0
+    v1.12.3 (default)
+```
+
+</details>
+
+<details><summary>In the `node-and-yarn` project</summary>
+
+```sh
+$ volta list yarn --format=human
+⚡️ Yarn versions in your toolchain:
+
+    v1.16.0 (current @ ~/node-and-yarn/package.json)
+    v1.12.3 (default)
+```
+
+</details>
+
+#### Plain
+
+The basic format is:
+
+```sh
+$ volta list <npm|yarn> --format=plain
+packager <packager>@<version> [(default|current @ <project path>)]
+```
+
+If the user has no packagers installed, output nothing.
+
+<details><summary>Outside a project</summary>
+
+```sh
+$ volta list yarn --format=plain
+packager yarn@v1.16.0
+packager yarn@v1.12.3 (default)
+```
+
+</details>
+
+<details><summary>In the `node-only` project</summary>
+
+```sh
+$ volta list yarn --format=plain
+packager yarn@v1.16.0
+packager yarn@v1.12.3 (default)
+```
+
+</details>
+
+<details><summary>In the `node-and-yarn` project</summary>
+
+```sh
+$ volta list yarn --format=plain
+packager yarn@v1.16.0 (current @ ~/node-and-yarn/package.json)
+packager yarn@v1.12.3 (default)
 ```
 
 </details>

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -129,15 +129,15 @@ Survey details:
 
 The `volta list` command supports four *variants*:
 
-- **no subcommand:** `volta list` – comparable to the existing `volta current`, but expanded to show not only the user’s current runtime but also their current packager and any available tool binaries, as well as explanation of why the current values are what they are
+- **`volta list`:** comparable to the existing `volta current`, but expanded. Shows not only the user’s current runtime but also their current packager and any available tool binaries, as well as explanation of why the current values are what they are.
 
-- **`--all`:** `volta list --all` – shows every fetched runtime, packager, and tool version, along with the binaries available for each tool, and an indication of whether each is a default or is set for a project in the user’s current working directory
+- **`volta list --all`:** shows every fetched runtime, packager, and tool version along with the binaries available for each tool. Also indicates of whether each is a default or is set for a project in the user’s current working directory.
 
-- **`package`:** `volta list package <package>` – shows a subset of the output from `--all`, scoped to the information for a specific package which has been fetched to the user’s inventory one or more times
+- **`volta list package <package>`:** shows a subset of the output from `--all`, scoped to the information for a specific package which has been fetched to the user’s inventory.
 
-- **`tool`:** `volta list tool <tool>` – shows a subset of the output from `--all`, scoped to the information for a specific tool which has been fetched to the user’s inventory one or more times; like `package` but if a package has more than one tool associated with it, only the specified tool will be shown
+- **`volta list tool <tool>`:** shows a subset of the output from `--all`, scoped to the information for a specific tool which has been fetched to the user’s inventory. `tool` is similar to `package`, but if a package has more than one tool associated with it, only the specified tool will be shown.
 
-It also supports (initially) two *output modes*: *human-friendly* (`human`) and *machine-friendly* (`plain`).
+The command also supports (initially) two *output modes*: *human-friendly* (`human`) and *machine-friendly* (`plain`).
 
 ## Information supplied by the command
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -98,14 +98,16 @@ Survey details:
 # Details
 [details]: #details
 
-There are variants of the command:
+The `volta list` command supports four *variants*:
 
 - with no flags: `volta list` – comparable to the existing `volta current`, but expanded to show not only the user’s current runtime but also their current packager and any available tool binaries, as well as explanation of why the current values are what they are
 - with `--all`: `volta list --all` – shows every fetched runtime, packager, and tool version, along with the binaries available for each tool, and an indication of whether each is a default or is set for a project in the user’s current working directory
 - with `--package`: `volta list --package=<package>` – shows a subset of the output from `--all`, scoped to the information for a specific package which has been fetched to the user’s inventory one or more times
 - with `--tool`: `volta list --tool=<tool>` – shows a subset of the output from `--all`, scoped to the information for a specific tool which has been fetched to the user’s inventory one or more times; like `--package` but if a package has more than one tool associated with it, only the specified tool will be shown
 
-## CLI Command Design
+It also supports (initially) two *output modes*: *human-friendly* (`human`) and *machine-friendly* (`plain`).
+
+## Command Output
 
 The `volta list` command always prints the following information for a set of runtimes, packagers, and tools:
 
@@ -113,6 +115,8 @@ The `volta list` command always prints the following information for a set of ru
 - version
 - whether it is the user's default or a project-pinned version
 - for tools, the associated runtime and packager versions
+
+## Output modes
 
 The tool will support multiple modes (two initially), which include exactly the same information but presented in different human- or machine-friendly formats. All modes include the same information for runtimes, packagers, and tools: name, version, whether it is a default or project-specified version, and (for tools) the Node version and packager (i.e. platform).
 
@@ -140,7 +144,9 @@ The tool will support multiple modes (two initially), which include exactly the 
 
 This RFC does not propose, but allows for the possibility of, a JSON mode (`--print=json`) or similar at a later time if that proves desirable.
 
-Below, this design is worked out in detailed examples.
+## Detailed Command Output
+
+Here we supply a worked example of each *variant* in both *output styles*.
 
 ### Assumed Configuration
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -136,7 +136,7 @@ See options for more detailed reports by running `volta list --help`.
 
 <details><summary>In the `node-only` project</summary>
 
-<b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436)
+<b>Note:</b> this assumes the implementation of a fix for [volta-cli/volta#436](https://github.com/volta-cli/volta/issues/436).
 
 ```sh
 $ volta list

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -194,7 +194,7 @@ Throughout, we will assume the user has the following configuration for illustra
 	    - v3.4.5 on Node v12.2.0 with built-in npm
 	    - v3.0.3 on Node v12.2.0 with built-in npm (default)
     - create-react-app, with binary `create-react-app`: v3.0.1 on Node v12.2.0 with built-in npm (default)
-    - yarn-deduplicate, with binary `yarn-deduplicate`: v1.1.1 on Node v12.2.0 with built-in npm (notice that this is not a *default*; assume the user ran `volta fetch` )
+    - yarn-deduplicate, with binary `yarn-deduplicate`: v1.1.1, fetched but not installed (and therefore with no associated platform)
 
 They also have two projects with the following pins:
 
@@ -404,9 +404,6 @@ $ volta list all --print=human
         yarn-deduplicate:
             v1.1.1
                 binaries: yarn-deduplicate
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
 ```
 
 </details>
@@ -460,9 +457,6 @@ $ volta list all --print=human
         yarn-deduplicate:
             v1.1.1
                 binaries: yarn-deduplicate
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
 ```
 
 </details>
@@ -516,9 +510,6 @@ $ volta list all --print=human
         yarn-deduplicate:
             v1.1.1
                 binaries: yarn-deduplicate
-                platform:
-                    runtime: node@v12.2.0
-                    packager: built-in npm
 ```
 
 </details>
@@ -551,7 +542,7 @@ tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1
 ```
 
 </details>
@@ -573,7 +564,7 @@ tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1
 ```
 
 </details>
@@ -595,7 +586,7 @@ tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
 tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
-tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1
 ```
 
 </details>

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -410,9 +410,9 @@ The basic format is:
 
 ```sh
 $ volta list --all
-runtime node@<version> [(default|<project path>)]
-packager <packager>@<version> [(default|<project path>)]
-tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|<project path>)]
+runtime node@<version> [(default|current @ <project path>)]
+packager <packager>@<version> [(default|current @ <project path>)]
+tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
 ```
 
 <details><summary>Outside a project directory</summary>

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -39,7 +39,7 @@ It is not necessary to write the actual feature documentation in this section, b
 
 ## Why `list`?
 
-Potential options include something like `list`, `ls`, `tools`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, `list` is the most flexible in terms of allowing variants to let the user describe *parts* of their toolchain as desired. It is also is a very common name for this operation in other tools (see the survey below). Additionally, choosing `list` as the primary name of the command does not preclude adding aliases for common operations later.
+Potential options include `list`, `ls`, `tools`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, `list` is the most flexible in terms of allowing variants to let the user describe *parts* of their toolchain as desired. It is also is a very common name for this operation in other tools (see the survey below). Additionally, choosing `list` as the primary name of the command does not preclude adding aliases for common operations later.
 
 ### Survey details
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -37,6 +37,64 @@ How should we explain and teach this feature to users? How should users understa
 It is not necessary to write the actual feature documentation in this section, but it should establish the concepts on which the documentation would be built.
 -->
 
+## Why `list`?
+
+Potential options include something like `list`, `ls`, `tools`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. 
+
+### Prior art
+
+A brief survey of the broader developer ecosystem indicates that `list` is by far the most common (sub)command used in CLI tools for listing installed versions of tools. The only major exception is `nodenv`, which (reasonably) seems to treat the "list" action as implicit in the user's intention, given that nodenv serves *only* to manage specific versions of Node. `nvm` uses `ls` and `ls-remote`, which are standard Unix shortenings of "list."
+
+Survey details:
+
+- `nvm` (and the other `*vm` tools):
+    - `ls` for installed versions
+    - `ls-remote` for available versions
+
+- `nodenv` (and the other `*env` tools) 
+    - `versions`: list all installed versions
+    - `version`: displays the currently-active version *and* how it was set
+    - `local`: list/set the version specified for a given directory tree, if any
+    - `global`: list/set the version specified for a global default, if any
+    - `shell`: list/set the version specified for a given shell, if any
+
+- [`dotnet`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet?tabs=netcore21)
+    - [`tool list`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-list), which requires either
+        - `-g, --global` -> lists “user-wide Global tools”; mutually exclusive with `--tool-path` variant
+        - `--tool-path <path>` -> a custom path to look for global tools; mutually exclusive with `--global` variant
+
+- [Chocolatey](https://chocolatey.org):
+    - `list`: searches for both local and remote packages, alias for `search`
+        - `-l, --lo, --localonly, --local-only`: only items on the local machine
+        - `-a, --all, --allversions, --all-versions`: results from all versions
+        - `--version=VALUE`: only this specific version match
+        - ` -e, --exact`: only exact matches for the name
+    - `info` for displaying details about a specific installed package
+
+- [Homebrew](https://brew.sh):
+    - `list`, `ls`
+    - takes a variety of arguments to limit the output:
+        - `--full-name`: give fully-qualified names
+        - `--versions`: show version number, takes an optional list of packages
+        - `--multiple`: only packages that have multiple versions installed
+        - `--pinned`: only for pinned formulae (things brew won’t upgrade without forcing)
+    - `info` for displaying 
+
+- [Scoop](https://scoop.sh):
+    - `list`
+
+- apt:
+    - `list`, lists `<source>/<package>,<package> <version> <arch>`
+    - explicitly does not have a stable CLI
+
+- yum:
+    - `list`: List package names from repositories
+        - `list available`: List all available packages
+        - `list installed`: List all installed packages
+        - `list all`: List installed and available packages
+        - `list kernel`: List installed and available kernel packages
+    - `info`: Display information about a package
+
 # Details
 [details]: #details
 
@@ -597,62 +655,6 @@ volta list --tool=tsc
 tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
 tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
 ```
-
-## Why `list`?
-
-### Prior art
-
-A brief survey of the broader developer ecosystem indicates that `list` is by far the most common (sub)command used in CLI tools for listing installed versions of tools. The only major exception is `nodenv`, which (reasonably) seems to treat the "list" action as implicit in the user's intention, given that nodenv serves *only* to manage specific versions of Node. `nvm` uses `ls` and `ls-remote`, which are standard Unix shortenings of "list."
-
-The survey details:
-
-- `nvm` (and the other `*vm` tools):
-    - `ls` for installed versions
-    - `ls-remote` for available versions
-
-- `nodenv` (and the other `*env` tools) 
-    - `versions`: list all installed versions
-    - `version`: displays the currently-active version *and* how it was set
-    - `local`: list/set the version specified for a given directory tree, if any
-    - `global`: list/set the version specified for a global default, if any
-    - `shell`: list/set the version specified for a given shell, if any
-
-- [`dotnet`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet?tabs=netcore21)
-    - [`tool list`](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-list), which requires either
-        - `-g, --global` -> lists “user-wide Global tools”; mutually exclusive with `--tool-path` variant
-        - `--tool-path <path>` -> a custom path to look for global tools; mutually exclusive with `--global` variant
-
-- [Chocolatey](https://chocolatey.org):
-    - `list`: searches for both local and remote packages, alias for `search`
-        - `-l, --lo, --localonly, --local-only`: only items on the local machine
-        - `-a, --all, --allversions, --all-versions`: results from all versions
-        - `--version=VALUE`: only this specific version match
-        - ` -e, --exact`: only exact matches for the name
-    - `info` for displaying details about a specific installed package
-
-- [Homebrew](https://brew.sh):
-    - `list`, `ls`
-    - takes a variety of arguments to limit the output:
-        - `--full-name`: give fully-qualified names
-        - `--versions`: show version number, takes an optional list of packages
-        - `--multiple`: only packages that have multiple versions installed
-        - `--pinned`: only for pinned formulae (things brew won’t upgrade without forcing)
-    - `info` for displaying 
-
-- [Scoop](https://scoop.sh):
-    - `list`
-
-- apt:
-    - `list`, lists `<source>/<package>,<package> <version> <arch>`
-    - explicitly does not have a stable CLI
-
-- yum:
-    - `list`: List package names from repositories
-        - `list available`: List all available packages
-        - `list installed`: List all installed packages
-        - `list all`: List installed and available packages
-        - `list kernel`: List installed and available kernel packages
-    - `info`: Display information about a package
 
 ## Deprecating `volta current`
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -73,7 +73,7 @@ $ volta list
 
     Node: v8.16.0 (from `~/pinned/node-only/package.json`)
     Yarn: v1.12.3 (default)
-    Package binaries available:
+    Tool binaries available:
         create-react-app, ember, tsc, tsserver, yarn-deduplicate
 
 See options for more detailed reports by running `volta list --help`.
@@ -97,35 +97,35 @@ Packagers:
 Tools:
     create-react-app:
         v3.0.1 (default)
-            bins: create-react-app
+            binaries: create-react-app
             platform:
                 runtime: node@v12.2.0
                 packager: built-in npm
     ember-cli:
         v3.10.0 (default)
-            bins: ember
+            binaries: ember
             platform:
                 runtime: node@v12.2.0
                 packager: built-in npm
         v3.8.2
-            bins: ember
+            binaries: ember
             platform:
                 runtime: node@v12.2.0
                 packager: built-in npm
     tsc:
         v3.4.5
-            bins: tsc, tsserver
+            binaries: tsc, tsserver
             platform:
                 runtime: node@v12.2.0
                 packager: built-in npm
         v3.0.3 (default)
-            bins: tsc, tsserver
+            binaries: tsc, tsserver
             platform:
                 runtime: node@v12.2.0
                 packager: built-in npm
     yarn-deduplicate:
         v1.1.1 (default)
-            bins: yarn-deduplicate
+            binaries: yarn-deduplicate
             platform:
                 runtime: node@v12.2.0
                 packager: built-in npm

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -11,24 +11,36 @@ Add an informational command, `volta list`, replacing the `volta current` comman
 # Motivation
 [motivation]: #motivation
 
-Why are we doing this? What use cases does it support? What is the expected outcome?
+Users of Volta currently have no way to get the answers to the following questions:
+
+- What versions of a runtime, packager, or tool do I have available already on my machine?
+- What versions of a runtime, packager, or tool are currently active? And why?
+- What versions of a runtime, packager, or tool are the *defaults* for the system?
+- What binaries are supplied by a given package which has been installed?
+- What Node version and packager are used by a given tool binary?
+
+The only tooling available to answer *any* of these question presently is the `volta current` command, which prints exactly and only the version of Node itself which will be executed in the user’s current directory. Users wanting to answer these questions today must resort to poking through the `~/.volta` directory, and its internals are *not* public API, so any tooling a user might put in place around that would be subject to breakage between versions.
+
+Adding a `volta list` command designed to address all of these needs allows users to get and use the information however they need. Adding it with both human- and tool-friendly output formats makes for a better user-experience: the default output will make it easy for people to *read*, and the machine-readable formats will make it easy for people to build *tools* around.
 
 # Pedagogy
 [pedagogy]: #pedagogy
 
+<!--
 How should we explain and teach this feature to users? How should users understand this feature? This generally means:
 
 - Introducing new named concepts.
 - Explaining the feature largely in terms of examples.
-- Explaining how users should _think_ about the feature, and how it should impact the way they use Notion. It should explain the impact as concretely as possible.
+- Explaining how users should _think_ about the feature, and how it should impact the way they use Volta. It should explain the impact as concretely as possible.
 - If applicable, describe the differences between teaching this to existing Node programmers and new Node programmers.
 
 It is not necessary to write the actual feature documentation in this section, but it should establish the concepts on which the documentation would be built.
+-->
 
 # Details
 [details]: #details
 
-## User configuration
+## Example configuration
 
 Throughout, we will assume the user has the following configuration for illustrative purposes:
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -19,7 +19,7 @@ Add an informational command, `volta list`, replacing the `volta current` comman
     - [Detailed Command Output](#detailed-command-output)
         - [Assumed Configuration](#assumed-configuration)
         - [`volta list` (no flags)](#volta-list-no-flags)
-        - [`volta list --all`](#volta-list---all)
+        - [`volta list all`](#volta-list-all)
         - [`volta list package <package>`](#volta-list-package-package)
         - [`volta list tool <tool>`](#volta-list-tool-tool)
     - [Deprecating `volta current`](#deprecating-volta-current)
@@ -52,7 +52,7 @@ We introduce a `list` command, which lets users get a description of their Volta
 
 - To get the currently-active runtime, packager, and available binaries, the user can run `volta list`.
 
-- To get *all* runtimes, packagers, and binaries currently fetched to the user's system, the user can run `volta list --all`.
+- To get *all* runtimes, packagers, and binaries currently fetched to the user's system, the user can run `volta list all`.
 
 - The user can also narrow the query:
     - to runtimes: `volta list node`
@@ -95,7 +95,7 @@ Survey details:
 - [Chocolatey](https://chocolatey.org):
     - `list`: searches for both local and remote packages, alias for `search`
         - `-l, --lo, --localonly, --local-only`: only items on the local machine
-        - `-a, --all, --allversions, --all-versions`: results from all versions
+        - `-a, all, allversions, all-versions`: results from all versions
         - `--version=VALUE`: only this specific version match
         - ` -e, --exact`: only exact matches for the name
     - `info` for displaying details about a specific installed package
@@ -131,11 +131,11 @@ The `volta list` command supports four *variants*:
 
 - **`volta list`:** comparable to the existing `volta current`, but expanded. Shows not only the user’s current runtime but also their current packager and any available tool binaries, as well as explanation of why the current values are what they are.
 
-- **`volta list --all`:** shows every fetched runtime, packager, and tool version along with the binaries available for each tool. Also indicates of whether each is a default or is set for a project in the user’s current working directory.
+- **`volta list all`:** shows every fetched runtime, packager, and tool version along with the binaries available for each tool. Also indicates of whether each is a default or is set for a project in the user’s current working directory.
 
-- **`volta list package <package>`:** shows a subset of the output from `--all`, scoped to the information for a specific package which has been fetched to the user’s inventory.
+- **`volta list package <package>`:** shows a subset of the output from `all`, scoped to the information for a specific package which has been fetched to the user’s inventory.
 
-- **`volta list tool <tool>`:** shows a subset of the output from `--all`, scoped to the information for a specific tool which has been fetched to the user’s inventory. `tool` is similar to `package`, but if a package has more than one tool associated with it, only the specified tool will be shown.
+- **`volta list tool <tool>`:** shows a subset of the output from `all`, scoped to the information for a specific tool which has been fetched to the user’s inventory. `tool` is similar to `package`, but if a package has more than one tool associated with it, only the specified tool will be shown.
 
 The command also supports (initially) two *output modes*: *human-friendly* (`human`) and *machine-friendly* (`plain`).
 
@@ -329,14 +329,14 @@ packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 
 </details>
 
-### `volta list --all`
+### `volta list all`
 
 #### Human
 
 The basic format is:
 
 ```sh
-$ volta list --all --human
+$ volta list all --human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -358,7 +358,7 @@ $ volta list --all --human
 <details><summary>Outside a project directory</summary>
 
 ```sh
-$ volta list --all --human
+$ volta list all --human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -414,7 +414,7 @@ $ volta list --all --human
 <details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-$ volta list --all --human
+$ volta list all --human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -470,7 +470,7 @@ $ volta list --all --human
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list --all --human
+$ volta list all --human
 ⚡️ User toolchain:
 
     Node runtimes:
@@ -528,7 +528,7 @@ $ volta list --all --human
 The basic format is:
 
 ```sh
-$ volta list --all --plain
+$ volta list all --plain
 runtime node@<version> [(default|current @ <project path>)]
 packager <packager>@<version> [(default|current @ <project path>)]
 tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|current @ <project path>)]
@@ -537,7 +537,7 @@ tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<versio
 <details><summary>Outside a project directory</summary>
 
 ```sh
-$ volta list --all --plain
+$ volta list all --plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -559,7 +559,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 <details><summary>In the <code>node-only</code> project</summary>
 
 ```sh
-$ volta list --all --plain
+$ volta list all --plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
@@ -581,7 +581,7 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in
 <details><summary>In the <code>node-and-yarn</code> project</summary>
 
 ```sh
-$ volta list --all --plain
+$ volta list all --plain
 runtime node@v12.2.0 (current @ ~/node-and-yarn/project.json)
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -108,12 +108,12 @@ The format is:
 
 ```sh
 $ volta list
-⚡️ Currently active toolchain:
+⚡️ Currently active tools:
 
-    Node: version [(default|<project path>)]
-    <packager>: <built-in|version> [(default|<project path>)]]
+    Node: v8.16.0 (default)
+    Yarn: v1.12.3 (default)
     Tool binaries available:
-        <comma separated list|NONE>
+        create-react-app, ember, tsc, tsserver, yarn-deduplicate
 
 See options for more detailed reports by running `volta list --help`.
 ```
@@ -122,7 +122,7 @@ See options for more detailed reports by running `volta list --help`.
 
 ```sh
 $ volta list
-⚡️ Currently active toolchain:
+⚡️ Currently active tools:
 
     Node: v8.16.0 (default)
     Yarn: v1.12.3 (default)
@@ -140,7 +140,7 @@ See options for more detailed reports by running `volta list --help`.
 
 ```sh
 $ volta list
-⚡️ Currently active toolchain:
+⚡️ Currently active tools:
 
     Node: v8.16.0 (from `~/node-only/package.json`)
     Yarn: v1.12.3 (default)
@@ -156,10 +156,10 @@ See options for more detailed reports by running `volta list --help`.
 
 ```sh
 $ volta list
-⚡️ Currently active toolchain:
+⚡️ Currently active tools:
 
-    Node: v12.2.0 (from `~/node-and-yarn/package.json`)
-    Yarn: v1.16.0 (from `~/node-and-yarn/package.json`)
+    Node runtime: v12.2.0 (from `~/node-and-yarn/package.json`)
+    Packager: Yarn: v1.16.0 (from `~/node-and-yarn/package.json`)
     Tool binaries available:
         create-react-app, ember, tsc, tsserver, yarn-deduplicate
 
@@ -204,8 +204,8 @@ packager yarn@v1.12.3 (default)
 
 ```sh
 $ volta list
-node@v12.2.0 (`~/node-and-yarn/package.json`)
-yarn@v1.16.0 (`~/node-and-yarn/package.json`)
+runtime node@v12.2.0 (`~/node-and-yarn/package.json`)
+packager yarn@v1.16.0 (`~/node-and-yarn/package.json`)
 ```
     
 </details>
@@ -218,72 +218,76 @@ The basic format is:
 
 ```sh
 $ volta list --all
-Node runtimes:
-    <version> [(default|<project path>)]
+⚡️ User toolchain:
 
-Packagers:
-    (Yarn|npm):
+    Node runtimes:
         <version> [(default|<project path>)]
-
-Tools:
-    <tool name>
-        <version> [(default|<project path>)]
-            binaries: [<binary name>]...
-            platform:
-                runtime: node@<version>
-                packager: built-in npm|<npm|yarn>@<version>
+    
+    Packagers:
+        (Yarn|npm):
+            <version> [(default|<project path>)]
+    
+    Tools:
+        <tool name>
+            <version> [(default|<project path>)]
+                binaries: [<binary name>]...
+                platform:
+                    runtime: node@<version>
+                    packager: built-in npm|<npm|yarn>@<version>
 ```
 
 <details><summary>Outside a project directory</summary>
 
 ```sh
 $ volta list --all
-Node runtimes:
-    v12.2.0
-    v11.9.0
-    v10.15.3 (default)
-    v8.16.0
+⚡️ User toolchain:
 
-Packagers:
-    Yarn:
-        v1.16.0 (default)
-        v1.12.3
-
-Tools:
-    create-react-app:
-        v3.0.1 (default)
-            binaries: create-react-app
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    ember-cli:
-        v3.10.0 (default)
-            binaries: ember
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-        v3.8.2
-            binaries: ember
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    tsc:
-        v3.4.5
-            binaries: tsc, tsserver
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-        v3.0.3 (default)
-            binaries: tsc, tsserver
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    yarn-deduplicate:
-        v1.1.1 (default)
-            binaries: yarn-deduplicate
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
+    Node runtimes:
+        v12.2.0
+        v11.9.0
+        v10.15.3 (default)
+        v8.16.0
+    
+    Packagers:
+        Yarn:
+            v1.16.0 (default)
+            v1.12.3
+    
+    Tools:
+        create-react-app:
+            v3.0.1 (default)
+                binaries: create-react-app
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        ember-cli:
+            v3.10.0 (default)
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.8.2
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        typescript:
+            v3.4.5
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.0.3 (default)
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        yarn-deduplicate:
+            v1.1.1 (default)
+                binaries: yarn-deduplicate
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
 ```
 
 </details>
@@ -292,52 +296,54 @@ Tools:
 
 ```sh
 $ volta list --all
-Node runtimes:
-    v12.2.0
-    v11.9.0
-    v10.15.3 (default)
-    v8.16.0 (current)
+⚡️ User toolchain:
 
-Packagers:
-    Yarn:
-        v1.16.0 (default)
-        v1.12.3
-
-Tools:
-    create-react-app:
-        v3.0.1 (default)
-            binaries: create-react-app
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    ember-cli:
-        v3.10.0 (default)
-            binaries: ember
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-        v3.8.2
-            binaries: ember
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    tsc:
-        v3.4.5
-            binaries: tsc, tsserver
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-        v3.0.3 (default)
-            binaries: tsc, tsserver
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    yarn-deduplicate:
-        v1.1.1 (default)
-            binaries: yarn-deduplicate
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
+    Node runtimes:
+        v12.2.0
+        v11.9.0
+        v10.15.3 (default)
+        v8.16.0 (current)
+    
+    Packagers:
+        Yarn:
+            v1.16.0 (default)
+            v1.12.3
+    
+    Tools:
+        create-react-app:
+            v3.0.1 (default)
+                binaries: create-react-app
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        ember-cli:
+            v3.10.0 (default)
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.8.2
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        tsc:
+            v3.4.5
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.0.3 (default)
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        yarn-deduplicate:
+            v1.1.1 (default)
+                binaries: yarn-deduplicate
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
 ```
 
 </details>
@@ -346,74 +352,199 @@ Tools:
 
 ```sh
 $ volta list --all
-Node runtimes:
-    v12.2.0 (`~/node-and-yarn/project.json`)
-    v11.9.0
-    v10.15.3 (default)
-    v8.16.0
+⚡️ User toolchain:
 
-Packagers:
-    Yarn:
-        v1.16.0 (default)
-        v1.12.3 (`~/node-and-yarn/project.json`)
-
-Tools:
-    create-react-app:
-        v3.0.1 (default)
-            binaries: create-react-app
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    ember-cli:
-        v3.10.0 (default)
-            binaries: ember
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-        v3.8.2
-            binaries: ember
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    tsc:
-        v3.4.5
-            binaries: tsc, tsserver
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-        v3.0.3 (default)
-            binaries: tsc, tsserver
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
-    yarn-deduplicate:
-        v1.1.1 (default)
-            binaries: yarn-deduplicate
-            platform:
-                runtime: node@v12.2.0
-                packager: built-in npm
+    Node runtimes:
+        v12.2.0 (`~/node-and-yarn/project.json`)
+        v11.9.0
+        v10.15.3 (default)
+        v8.16.0
+    
+    Packagers:
+        Yarn:
+            v1.16.0 (default)
+            v1.12.3 (`~/node-and-yarn/project.json`)
+    
+    Tools:
+        create-react-app:
+            v3.0.1 (default)
+                binaries: create-react-app
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        ember-cli:
+            v3.10.0 (default)
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.8.2
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        tsc:
+            v3.4.5
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.0.3 (default)
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        yarn-deduplicate:
+            v1.1.1 (default)
+                binaries: yarn-deduplicate
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
 ```
 
 </details>
 
 #### Plain
 
-<details><summary></summary>
+The basic format is:
+
+```sh
+$ volta list --all
+runtime node@<version> [(default|<project path>)]
+packager <packager>@<version> [(default|<project path>)]
+tool <tool name> / <package>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|<project path>)]
+```
+
+<details><summary>Outside a project directory</summary>
 
 ```sh
 $ volta list --all
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
-runtime node@v8.16.0
-packager yarn@v1.16.0
-packager yarn@v1.12.3 (default)
-tool create-react-app@v3.0.1 (default) / node@v12.2.0
-tool ember-cli@v3.10.0 (default) / node@v12.2.0
-tool ember-cli@v3.8.2 / node@v12.2.0
-tool typescript@v3.4.5 / node@v12.2.0
-tool typescript@v3.0.3 (default) / node@v12.2.0
-tool yarn-deduplicate@v1.1.1 / node@v12.2.0
+runtime node@v8.16.0    
+packager yarn@v1.16.0 (default)
+packager yarn@v1.12.3
+tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
+tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
+tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in
+tool tsc / typescript@v3.4.5 node@v12.2.0 npm@built-in
+tool tsserver / typescript@v3.4.5 node@v12.2.0 npm@built-in
+tool tsc / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
+tool tsserver / typescript@v3.0.3 node@v12.2.0 npm@built-in (default)
+tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (default)
+```
+
+</details>
+
+<details><summary>In the <code>node-only</code> project</summary>
+
+```sh
+$ volta list --all
+⚡️ User toolchain:
+
+    Node runtimes:
+        v12.2.0
+        v11.9.0
+        v10.15.3 (default)
+        v8.16.0 (current)
+    
+    Packagers:
+        Yarn:
+            v1.16.0 (default)
+            v1.12.3
+    
+    Tools:
+        create-react-app:
+            v3.0.1 (default)
+                binaries: create-react-app
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        ember-cli:
+            v3.10.0 (default)
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.8.2
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        tsc:
+            v3.4.5
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.0.3 (default)
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        yarn-deduplicate:
+            v1.1.1 (default)
+                binaries: yarn-deduplicate
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+```
+
+</details>
+
+<details><summary>In the <code>node-and-yarn</code> project</summary>
+
+```sh
+$ volta list --all
+⚡️ User toolchain:
+
+    Node runtimes:
+        v12.2.0 (`~/node-and-yarn/project.json`)
+        v11.9.0
+        v10.15.3 (default)
+        v8.16.0
+    
+    Packagers:
+        Yarn:
+            v1.16.0 (default)
+            v1.12.3 (`~/node-and-yarn/project.json`)
+    
+    Tools:
+        create-react-app:
+            v3.0.1 (default)
+                binaries: create-react-app
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        ember-cli:
+            v3.10.0 (default)
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.8.2
+                binaries: ember
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        tsc:
+            v3.4.5
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+            v3.0.3 (default)
+                binaries: tsc, tsserver
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
+        yarn-deduplicate:
+            v1.1.1 (default)
+                binaries: yarn-deduplicate
+                platform:
+                    runtime: node@v12.2.0
+                    packager: built-in npm
 ```
 
 </details>
@@ -516,7 +647,7 @@ This section discusses the tradeoffs considered in this proposal. This must incl
     - a subset of package binaries once the number crosses a threshold, with instructions about how to see all?
     - no package binaries?
 
-    And how should that be presented in `plain` vs. `human` mode?
+    And how should that be presented in `plain` vs. `human` mode? Should there be any differences between `plain` and `human` for the bare command (as in the current design)?
 
 <!-- 
 - What parts of the design do you expect to resolve through the RFC process before this gets merged?

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -133,9 +133,9 @@ The `volta list` command supports four *variants*:
 
 - **`volta list all`:** shows every fetched runtime, packager, and tool version along with the binaries available for each tool. Also indicates of whether each is a default or is set for a project in the user’s current working directory.
 
-- **`volta list package <package>`:** shows a subset of the output from `all`, scoped to the information for a specific package which has been fetched to the user’s inventory.
+- **`volta list <package>`:** shows a subset of the output from `all`, scoped to the information for a specific package which has been fetched to the user’s inventory.
 
-- **`volta list tool <tool>`:** shows a subset of the output from `all`, scoped to the information for a specific tool which has been fetched to the user’s inventory. `tool` is similar to `package`, but if a package has more than one tool associated with it, only the specified tool will be shown.
+- **`volta list <tool>`:** shows a subset of the output from `all`, scoped to the information for a specific tool which has been fetched to the user’s inventory. `tool` is similar to `package`, but if a package has more than one tool associated with it, only the specified tool will be shown.
 
 The command also supports (initially) two *output modes*: *human-friendly* (`human`) and *machine-friendly* (`plain`).
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -142,7 +142,7 @@ See options for more detailed reports by running `volta list --help`.
 $ volta list --human
 ⚡️ Currently active tools:
 
-    Node: v8.16.0 (from `~/node-only/package.json`)
+    Node: v8.16.0 (current @ ~/node-only/package.json)
     Yarn: v1.12.3 (default)
     Tool binaries available:
         create-react-app, ember, tsc, tsserver, yarn-deduplicate
@@ -158,8 +158,8 @@ See options for more detailed reports by running `volta list --help`.
 $ volta list --human
 ⚡️ Currently active tools:
 
-    Node runtime: v12.2.0 (from `~/node-and-yarn/package.json`)
-    Packager: Yarn: v1.16.0 (from `~/node-and-yarn/package.json`)
+    Node runtime: v12.2.0 (current @ ~/node-and-yarn/package.json)
+    Packager: Yarn: v1.16.0 (current @ ~/node-and-yarn/package.json)
     Tool binaries available:
         create-react-app, ember, tsc, tsserver, yarn-deduplicate
 
@@ -174,7 +174,7 @@ The format is:
 
 ```sh
 $ volta list --plain
-runtime node@<version> (default|current@ <project path>)
+runtime node@<version> (default|current @  <project path>)
 packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 ```
 
@@ -444,7 +444,7 @@ $ volta list --all --plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
-runtime node@v8.16.0 (current@~/node-only/package.json)
+runtime node@v8.16.0 (current @ ~/node-only/package.json)
 packager yarn@v1.16.0 (default)
 packager yarn@v1.12.3
 tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
@@ -463,12 +463,12 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (defau
 
 ```sh
 $ volta list --all --plain
-runtime node@v12.2.0 (current@~/node-and-yarn/project.json)
+runtime node@v12.2.0 (current @ ~/node-and-yarn/project.json)
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
 runtime node@v8.16.0
 packager yarn@v1.16.0 (default)
-packager yarn@v1.12.3 (current@~/node-and-yarn/project.json)
+packager yarn@v1.12.3 (current @ ~/node-and-yarn/project.json)
 tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
 tool ember / ember-cli@v3.10.0 node@v12.2.0 npm@built-in (default)
 tool ember / ember-cli@v3.8.2 node@v12.2.0 npm@built-in

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -481,15 +481,61 @@ tool yarn-deduplicate / yarn-deduplicate@v1.1.1 node@v12.2.0 npm@built-in (defau
 
 </details>
 
-### `volta list <package>`
+### `volta list --package=<package>`
 
-List all fetched versions of a specific package:
+List all fetched versions of a specific package.
+
+#### Human
+
+The basic format is:
 
 ```sh
-volta list <package>
+volta list --package=<package> --human
+
+    <version> [(default|current @ <project path>)]
+        binaries: [<binary name>]...
+        platform:
+            runtime: node@<version>
+            packager: built-in npm|<npm|yarn>@<version>
 ```
 
-<!-- TODO: remaining examples! -->
+For the TypeScript config specified in the canonical example:
+
+```sh
+volta list --package=typescript --human
+
+    v3.4.5
+        binaries: tsc, tsserver
+        platform:
+            runtime: node@v12.2.0
+            packager: built-in npm
+
+    v3.0.3 (default)
+        binaries: tsc, tsserver
+        platform:
+            runtime: node@v12.2.0
+            packager: built-in npm
+```
+
+#### Plain
+
+The basic format is:
+
+```sh
+volta list --package=<package> --plain
+tool <tool> / <package>@<version> node@<version> <npm|yarn>@<built-in|version> [(default|current @ <path>)]
+```
+
+For the TypeScript config specified in the canonical example:
+
+```sh
+volta list --package=typescript
+tool tsc / typescript@v3.4.5 node@12.2.0 npm@built-in
+tool tsserver / typescript@v3.4.5 node@12.2.0 npm@built-in
+tool tsc / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
+tool tsserver / typescript@v3.0.3 node@12.2.0 npm@built-in (default)
+```
+
 
 ## Why `list`?
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -39,7 +39,7 @@ It is not necessary to write the actual feature documentation in this section, b
 
 ## Why `list`?
 
-Potential options include something like `list`, `ls`, `tools`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. 
+Potential options include something like `list`, `ls`, `tools`, `info`, `current`, or simply bare names like `node`, `yarn`, or `<package>` or `<tool>`. However, as the tool survey below indicates, `list` is by far the most common name for this operation among other tools, and it is also the most flexible in terms of allowing variants to let the user describe *parts* of their toolchain as desired.
 
 ### Prior art
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -56,9 +56,9 @@ We introduce a `list` command, which lets users get a description of their Volta
 
 - The user can also narrow the query:
     - to runtimes: `volta list node`
-    - to packagers: `volta list npm` or `volta list yarn`
-    - to a specific package: `volta list package <package name>`
-    - to a specific tool: `volta list tool <tool name>`
+    - to packagers: `volta list yarn` (and, when custom installations of `npm` are supported, `volta list npm`)
+    - to a specific package: `volta list <package name>`
+    - to a specific tool: `volta list <tool name>`
 
 These commands represent the Volta ideas of the user's *toolchain*, including *default* and *current* items within that chain.
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -1,7 +1,7 @@
 - Feature Name: informational_commands
 - Start Date: 2019-05-15
 - RFC PR: (leave this empty)
-- Notion Issue: (leave this empty)
+- Volta Issue: (leave this empty)
 
 # Summary
 [summary]: #summary
@@ -72,9 +72,9 @@ The `volta list` command always prints the following information for a set of ru
 - whether it is the user's default or a project-pinned version
 - for tools, the associated runtime and packager versions
 
-The tool will support two modes initially: "human" and "plain", which include exactly the same information but presented in a  Both modes include the same information for runtimes, packagers, and tools: name, version, whether it is a default or project-specified version, and (for tools) the Node version and packager (i.e. platform).
+The tool will support multiple modes (two initially), which include exactly the same information but presented in different human- or machine-friendly formats. All modes include the same information for runtimes, packagers, and tools: name, version, whether it is a default or project-specified version, and (for tools) the Node version and packager (i.e. platform).
 
-- "human" mode, the default if the context is a user-facing terminal; also invokable with `--print=human` in any context.
+- "human" mode, the default if the context is a user-facing terminal; also invokable with `--print=human` in any context. An indented listing of the user's current runtime, packager (if specified), and any installed binaries. See the detailed sections below for examples of the format.
 
 - "plain" mode, the default if the context is not a user-facing terminal (e.g. when piped into another command); also invokable with `--print=plain` in any context. A simple plain text format which prints a line per runtime, packager, or tool, with space-separated output on each line.
 
@@ -96,7 +96,7 @@ The tool will support two modes initially: "human" and "plain", which include ex
         tool <tool name>@<tool version> [node@<version>] [<yarn|npm>@<version>] [(default|<project path>)]
         ```
 
-Having these two modes should make it easy to add a JSON mode later (`--print=json`) if that proves desirable.
+This RFC does not propose, but allows for the possibility of, a JSON mode (`--print=json`) or similar at a later time if that proves desirable.
 
 ## CLI Command Variants
 

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -271,7 +271,7 @@ The format is:
 
 ```sh
 $ volta list --plain
-runtime node@<version> (default|current @  <project path>)
+runtime node@<version> (default|current @ <project path>)
 packager <npm|yarn>@<version> (built-in|default|current @ <project path>)
 ```
 
@@ -304,9 +304,9 @@ $ volta list --plain
 runtime node@v12.2.0 (~/node-and-yarn/package.json)
 packager yarn@v1.16.0 (~/node-and-yarn/package.json)
 ```
-    
+
 </details>
-    
+
 ### `volta list --all`
 
 #### Human
@@ -519,7 +519,7 @@ $ volta list --all --plain
 runtime node@v12.2.0
 runtime node@v11.9.0
 runtime node@v10.15.3 (default)
-runtime node@v8.16.0    
+runtime node@v8.16.0
 packager yarn@v1.16.0 (default)
 packager yarn@v1.12.3
 tool create-react-app / create-react-app@v3.0.1 node@v12.2.0 npm@built-in (default)
@@ -755,4 +755,3 @@ We could leave the current state of affairs as it is. However, users then have n
 - How should the built-in version of `npm` be displayed to the user? Options include:
     - associated with the runtime it ships with, e.g. `v12.2.0 (with npm v6.4.1)`
     - as a packager, but indicating its source as a built-in, e.g. `npm v6.4.1 (built-in from node@v12.2.0`
-

--- a/text/0000-informational-commands.md
+++ b/text/0000-informational-commands.md
@@ -176,7 +176,7 @@ The tool will support multiple modes (two initially), which include exactly the 
 
 This RFC does not propose, but allows for the possibility of, a JSON mode (`--print=json`) or similar at a later time if that proves desirable.
 
-## Detailed Command Output
+## Detailed command output
 
 Here we supply a worked example of each *variant* in both *output styles*.
 


### PR DESCRIPTION
 [Rendered RFC text](https://github.com/volta-cli/rfcs/blob/info-commands/text/0000-informational-commands.md). See earlier discussion at volta-cli/volta#349.

> Add an informational command, `volta list`, replacing the `volta current` command and expanding on its capabilities. The `list` command will allow users to see their default and project-specific toolchains, and will support both human-friendly output and a tool-friendly output.